### PR TITLE
Lexer/parser: Pine line-wrapping rule + dangling Dedents between call arguments

### DIFF
--- a/crates/pine-lexer/src/lib.rs
+++ b/crates/pine-lexer/src/lib.rs
@@ -714,40 +714,57 @@ impl Lexer {
                     break;
                 }
 
-                // Handle indent/dedent
-                // SAFETY: indent_stack is initialized with vec![0] and we never pop the last element
-                let current_indent = *self.indent_stack.last().unwrap();
-                let line = saved_line;
-                let col = saved_col;
+                if indent_level % 4 != 0 {
+                    // Pine line-wrapping: a line indented by a non-multiple of
+                    // 4 spaces continues the previous logical line (Pine
+                    // reserves 4-space multiples for local blocks). Join it to
+                    // the previous line: drop the Newline that ended it and
+                    // leave the indent stack untouched.
+                    if matches!(
+                        tokens.last(),
+                        Some(Token {
+                            typ: TokenType::Newline,
+                            ..
+                        })
+                    ) {
+                        tokens.pop();
+                    }
+                } else {
+                    // Handle indent/dedent
+                    // SAFETY: indent_stack is initialized with vec![0] and we never pop the last element
+                    let current_indent = *self.indent_stack.last().unwrap();
+                    let line = saved_line;
+                    let col = saved_col;
 
-                if indent_level > current_indent {
-                    // Indent
-                    self.indent_stack.push(indent_level);
-                    tokens.push(Token {
-                        typ: TokenType::Indent,
-                        lexeme: String::new(),
-                        line,
-                        column: col,
-                    });
-                } else if indent_level < current_indent {
-                    // Dedent - possibly multiple levels
-                    // SAFETY: checked by len() > 1
-                    while self.indent_stack.len() > 1
-                        && *self.indent_stack.last().unwrap() > indent_level
-                    {
-                        self.indent_stack.pop();
+                    if indent_level > current_indent {
+                        // Indent
+                        self.indent_stack.push(indent_level);
                         tokens.push(Token {
-                            typ: TokenType::Dedent,
+                            typ: TokenType::Indent,
                             lexeme: String::new(),
                             line,
                             column: col,
                         });
-                    }
+                    } else if indent_level < current_indent {
+                        // Dedent - possibly multiple levels
+                        // SAFETY: checked by len() > 1
+                        while self.indent_stack.len() > 1
+                            && *self.indent_stack.last().unwrap() > indent_level
+                        {
+                            self.indent_stack.pop();
+                            tokens.push(Token {
+                                typ: TokenType::Dedent,
+                                lexeme: String::new(),
+                                line,
+                                column: col,
+                            });
+                        }
 
-                    // Check for indentation error
-                    // SAFETY: indent_stack always has at least one element
-                    if *self.indent_stack.last().unwrap() != indent_level {
-                        return Err(LexerError::IndentationError { line });
+                        // Check for indentation error
+                        // SAFETY: indent_stack always has at least one element
+                        if *self.indent_stack.last().unwrap() != indent_level {
+                            return Err(LexerError::IndentationError { line });
+                        }
                     }
                 }
             }
@@ -788,6 +805,52 @@ impl Lexer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_line_wrapping_non_multiple_of_4_joins_lines() -> eyre::Result<()> {
+        // Pine line-wrapping rule: a line indented by a non-multiple of 4
+        // spaces continues the previous logical line (4-space multiples are
+        // reserved for local blocks). The wrapped lines must produce NO
+        // Newline before the continuation and NO Indent/Dedent tokens.
+        let mut lexer = Lexer::new("a = x < 2\n         and y\nb = 1");
+        let tokens = lexer.tokenize()?;
+        assert!(
+            !tokens
+                .iter()
+                .any(|t| matches!(t.typ, TokenType::Indent | TokenType::Dedent)),
+            "wrapped continuation must not emit Indent/Dedent: {:?}",
+            tokens.iter().map(|t| &t.typ).collect::<Vec<_>>()
+        );
+        // `a = x < 2 and y` must be one logical line: the only Newline comes
+        // after `y` (plus optionally after `b = 1`).
+        let and_pos = tokens
+            .iter()
+            .position(|t| matches!(t.typ, TokenType::And))
+            .expect("And token present");
+        assert!(
+            !tokens[..and_pos]
+                .iter()
+                .any(|t| matches!(t.typ, TokenType::Newline)),
+            "no Newline may precede the continuation's `and`: {:?}",
+            tokens.iter().map(|t| &t.typ).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_indent_multiple_of_4_still_indents() -> eyre::Result<()> {
+        let mut lexer = Lexer::new("if cond\n    x = 1\ny = 2");
+        let tokens = lexer.tokenize()?;
+        assert!(
+            tokens.iter().any(|t| matches!(t.typ, TokenType::Indent)),
+            "4-space block body must still emit Indent"
+        );
+        assert!(
+            tokens.iter().any(|t| matches!(t.typ, TokenType::Dedent)),
+            "return to column 0 must still emit Dedent"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_literals() -> eyre::Result<()> {

--- a/crates/pine-parser/src/lib.rs
+++ b/crates/pine-parser/src/lib.rs
@@ -1743,66 +1743,6 @@ mod tests {
     }
 
     #[test]
-    fn test_line_wrapped_bool_expression() {
-        // Pine line-wrapping: continuation lines indented by a non-multiple
-        // of 4 spaces join the previous logical line. Bare `and`/`or` at the
-        // start of a continuation line is the canonical Pine style:
-        //   can_trade = a < 2
-        //            and b
-        //            and c
-        let src = "can_trade = x < 2\n         and y\n         and z\nnext_var = 1";
-        let tokens = Lexer::new(src).tokenize().unwrap();
-        let stmts = Parser::new(tokens).parse().unwrap();
-        assert_eq!(
-            stmts.len(),
-            2,
-            "wrapped expression must parse as ONE statement: {:?}",
-            stmts
-        );
-        if let Stmt::VarDecl {
-            name, initializer, ..
-        } = &stmts[0]
-        {
-            assert_eq!(name, "can_trade");
-            // Initializer must be ((x < 2) and y) and z.
-            let init = initializer.as_ref().unwrap();
-            assert!(
-                matches!(init, Expr::Binary { op: BinOp::And, .. }),
-                "wrapped initializer must be an And chain, got {:?}",
-                init
-            );
-        } else {
-            panic!("Expected VarDecl, got {:?}", stmts[0]);
-        }
-    }
-
-    #[test]
-    fn test_line_wrapped_ternary_inside_block() {
-        // Wrapped ternary on a continuation line inside an if-block
-        // (block indent 4; continuation indent 15 — not a multiple of 4).
-        let src = "if cond\n    s = a > 0 ? 1 :\n               b < 0 ? 2 : 3\nq = 1";
-        let tokens = Lexer::new(src).tokenize().unwrap();
-        let stmts = Parser::new(tokens).parse().unwrap();
-        assert_eq!(stmts.len(), 2, "expected if-stmt + q decl: {:?}", stmts);
-        assert!(
-            matches!(&stmts[0], Stmt::If { .. }),
-            "first stmt must be If: {:?}",
-            stmts[0]
-        );
-    }
-
-    #[test]
-    fn test_multiline_ternary_named_argument() {
-        // A named argument whose value is a ternary wrapped onto an indented
-        // continuation line leaves a closing Dedent in the token stream after
-        // the comma; arguments() must consume it before the next argument.
-        let src = "x = f(a = 1,\n    b = cond ? 1 :\n        2,\n    c = 3)\ny = 1";
-        let tokens = Lexer::new(src).tokenize().unwrap();
-        let stmts = Parser::new(tokens).parse().unwrap();
-        assert_eq!(stmts.len(), 2, "expected x decl + y decl: {:?}", stmts);
-    }
-
-    #[test]
     fn test_literals() {
         // Numbers
         let expr = parse_expr("42").unwrap();

--- a/crates/pine-parser/src/lib.rs
+++ b/crates/pine-parser/src/lib.rs
@@ -1538,8 +1538,31 @@ impl Parser {
                     break;
                 }
 
-                // Skip newlines after comma
-                self.skip_newlines_and_indent();
+                // Skip newlines after comma. The previous argument's value may have
+                // used an indented continuation (multiline ternary), leaving a closing
+                // Dedent in the stream before the next argument. Consume any such
+                // Dedents, then consume an optional Indent if the next argument is
+                // itself on an indented line.
+                self.skip_newlines();
+                while self.check(&TokenType::Dedent) {
+                    // Only consume Dedents that are not the argument list's own
+                    // closing Dedent (which would be immediately followed by RParen).
+                    let consumed = self.try_parse(|p| {
+                        p.advance(); // consume Dedent
+                        if p.check(&TokenType::RParen) {
+                            Err(ParserError::UnexpectedToken(
+                                p.peek().typ.clone(),
+                                p.peek().line,
+                            ))
+                        } else {
+                            Ok(())
+                        }
+                    });
+                    if consumed.is_none() {
+                        break;
+                    }
+                }
+                self.match_token(&[TokenType::Indent]);
             }
         }
 
@@ -1717,6 +1740,17 @@ mod tests {
         } else {
             Err(eyre::eyre!("Expected expression statement".to_string()))
         }
+    }
+
+    #[test]
+    fn test_multiline_ternary_named_argument() {
+        // A named argument whose value is a ternary wrapped onto an indented
+        // continuation line leaves a closing Dedent in the token stream after
+        // the comma; arguments() must consume it before the next argument.
+        let src = "x = f(a = 1,\n    b = cond ? 1 :\n        2,\n    c = 3)\ny = 1";
+        let tokens = Lexer::new(src).tokenize().unwrap();
+        let stmts = Parser::new(tokens).parse().unwrap();
+        assert_eq!(stmts.len(), 2, "expected x decl + y decl: {:?}", stmts);
     }
 
     #[test]

--- a/crates/pine-parser/src/lib.rs
+++ b/crates/pine-parser/src/lib.rs
@@ -1743,6 +1743,55 @@ mod tests {
     }
 
     #[test]
+    fn test_line_wrapped_bool_expression() {
+        // Pine line-wrapping: continuation lines indented by a non-multiple
+        // of 4 spaces join the previous logical line. Bare `and`/`or` at the
+        // start of a continuation line is the canonical Pine style:
+        //   can_trade = a < 2
+        //            and b
+        //            and c
+        let src = "can_trade = x < 2\n         and y\n         and z\nnext_var = 1";
+        let tokens = Lexer::new(src).tokenize().unwrap();
+        let stmts = Parser::new(tokens).parse().unwrap();
+        assert_eq!(
+            stmts.len(),
+            2,
+            "wrapped expression must parse as ONE statement: {:?}",
+            stmts
+        );
+        if let Stmt::VarDecl {
+            name, initializer, ..
+        } = &stmts[0]
+        {
+            assert_eq!(name, "can_trade");
+            // Initializer must be ((x < 2) and y) and z.
+            let init = initializer.as_ref().unwrap();
+            assert!(
+                matches!(init, Expr::Binary { op: BinOp::And, .. }),
+                "wrapped initializer must be an And chain, got {:?}",
+                init
+            );
+        } else {
+            panic!("Expected VarDecl, got {:?}", stmts[0]);
+        }
+    }
+
+    #[test]
+    fn test_line_wrapped_ternary_inside_block() {
+        // Wrapped ternary on a continuation line inside an if-block
+        // (block indent 4; continuation indent 15 — not a multiple of 4).
+        let src = "if cond\n    s = a > 0 ? 1 :\n               b < 0 ? 2 : 3\nq = 1";
+        let tokens = Lexer::new(src).tokenize().unwrap();
+        let stmts = Parser::new(tokens).parse().unwrap();
+        assert_eq!(stmts.len(), 2, "expected if-stmt + q decl: {:?}", stmts);
+        assert!(
+            matches!(&stmts[0], Stmt::If { .. }),
+            "first stmt must be If: {:?}",
+            stmts[0]
+        );
+    }
+
+    #[test]
     fn test_multiline_ternary_named_argument() {
         // A named argument whose value is a ternary wrapped onto an indented
         // continuation line leaves a closing Dedent in the token stream after

--- a/crates/pine-parser/testdata/syntax/line_wrapped_bool_expression.pine
+++ b/crates/pine-parser/testdata/syntax/line_wrapped_bool_expression.pine
@@ -1,0 +1,10 @@
+//@version=4
+
+// Pine line-wrapping: continuation lines indented by a non-multiple of 4
+// spaces join the previous logical line. A bare `and`/`or` at the start of a
+// continuation line is the canonical Pine style.
+can_trade = x < 2
+         and y
+         and z
+
+next_var = 1

--- a/crates/pine-parser/testdata/syntax/line_wrapped_bool_expression_ast.json
+++ b/crates/pine-parser/testdata/syntax/line_wrapped_bool_expression_ast.json
@@ -1,0 +1,50 @@
+[
+  {
+    "VarDecl": {
+      "name": "can_trade",
+      "type_annotation": null,
+      "initializer": {
+        "Binary": {
+          "left": {
+            "Binary": {
+              "left": {
+                "Binary": {
+                  "left": {
+                    "Variable": "x"
+                  },
+                  "op": "Less",
+                  "right": {
+                    "Literal": {
+                      "Number": 2.0
+                    }
+                  }
+                }
+              },
+              "op": "And",
+              "right": {
+                "Variable": "y"
+              }
+            }
+          },
+          "op": "And",
+          "right": {
+            "Variable": "z"
+          }
+        }
+      },
+      "is_varip": false
+    }
+  },
+  {
+    "VarDecl": {
+      "name": "next_var",
+      "type_annotation": null,
+      "initializer": {
+        "Literal": {
+          "Number": 1.0
+        }
+      },
+      "is_varip": false
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/line_wrapped_ternary_in_block.pine
+++ b/crates/pine-parser/testdata/syntax/line_wrapped_ternary_in_block.pine
@@ -1,0 +1,12 @@
+//@version=4
+
+// Line wrapping inside a local block: the block indent is 4, while the
+// continuation indents (9 and 15) are not multiples of 4, so those lines join
+// the previous logical line instead of opening a nested block.
+if cond
+    v = x < 2
+         and y
+    s = a > 0 ? 1 :
+               b < 0 ? 2 : 3
+
+q = 1

--- a/crates/pine-parser/testdata/syntax/line_wrapped_ternary_in_block_ast.json
+++ b/crates/pine-parser/testdata/syntax/line_wrapped_ternary_in_block_ast.json
@@ -1,0 +1,109 @@
+[
+  {
+    "If": {
+      "condition": {
+        "Variable": "cond"
+      },
+      "then_branch": [
+        {
+          "VarDecl": {
+            "name": "v",
+            "type_annotation": null,
+            "initializer": {
+              "Binary": {
+                "left": {
+                  "Binary": {
+                    "left": {
+                      "Variable": "x"
+                    },
+                    "op": "Less",
+                    "right": {
+                      "Literal": {
+                        "Number": 2.0
+                      }
+                    }
+                  }
+                },
+                "op": "And",
+                "right": {
+                  "Variable": "y"
+                }
+              }
+            },
+            "is_varip": false
+          }
+        },
+        {
+          "VarDecl": {
+            "name": "s",
+            "type_annotation": null,
+            "initializer": {
+              "Ternary": {
+                "condition": {
+                  "Binary": {
+                    "left": {
+                      "Variable": "a"
+                    },
+                    "op": "Greater",
+                    "right": {
+                      "Literal": {
+                        "Number": 0.0
+                      }
+                    }
+                  }
+                },
+                "then_expr": {
+                  "Literal": {
+                    "Number": 1.0
+                  }
+                },
+                "else_expr": {
+                  "Ternary": {
+                    "condition": {
+                      "Binary": {
+                        "left": {
+                          "Variable": "b"
+                        },
+                        "op": "Less",
+                        "right": {
+                          "Literal": {
+                            "Number": 0.0
+                          }
+                        }
+                      }
+                    },
+                    "then_expr": {
+                      "Literal": {
+                        "Number": 2.0
+                      }
+                    },
+                    "else_expr": {
+                      "Literal": {
+                        "Number": 3.0
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "is_varip": false
+          }
+        }
+      ],
+      "else_if_branches": [],
+      "else_branch": null
+    }
+  },
+  {
+    "VarDecl": {
+      "name": "q",
+      "type_annotation": null,
+      "initializer": {
+        "Literal": {
+          "Number": 1.0
+        }
+      },
+      "is_varip": false
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/multiline_ternary_named_argument.pine
+++ b/crates/pine-parser/testdata/syntax/multiline_ternary_named_argument.pine
@@ -1,0 +1,11 @@
+//@version=4
+
+// A named argument whose value is a ternary wrapped onto an indented
+// continuation line leaves a closing Dedent in the token stream after the
+// comma; the argument list must consume it before the next argument.
+x = f(a = 1,
+    b = cond ? 1 :
+        2,
+    c = 3)
+
+y = 1

--- a/crates/pine-parser/testdata/syntax/multiline_ternary_named_argument_ast.json
+++ b/crates/pine-parser/testdata/syntax/multiline_ternary_named_argument_ast.json
@@ -1,0 +1,72 @@
+[
+  {
+    "VarDecl": {
+      "name": "x",
+      "type_annotation": null,
+      "initializer": {
+        "Call": {
+          "callee": {
+            "Variable": "f"
+          },
+          "args": [
+            {
+              "Named": {
+                "name": "a",
+                "value": {
+                  "Literal": {
+                    "Number": 1.0
+                  }
+                }
+              }
+            },
+            {
+              "Named": {
+                "name": "b",
+                "value": {
+                  "Ternary": {
+                    "condition": {
+                      "Variable": "cond"
+                    },
+                    "then_expr": {
+                      "Literal": {
+                        "Number": 1.0
+                      }
+                    },
+                    "else_expr": {
+                      "Literal": {
+                        "Number": 2.0
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "Named": {
+                "name": "c",
+                "value": {
+                  "Literal": {
+                    "Number": 3.0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "is_varip": false
+    }
+  },
+  {
+    "VarDecl": {
+      "name": "y",
+      "type_annotation": null,
+      "initializer": {
+        "Literal": {
+          "Number": 1.0
+        }
+      },
+      "is_varip": false
+    }
+  }
+]


### PR DESCRIPTION
## Summary

This is the lexer/parser slice of #49, split out (as offered there) so each piece can be reviewed on its own. The code is unchanged from #49 — the commits are cherry-picked as-is. The three split PRs are independent: each compiles and passes the full workspace suite standalone (`cargo test`, `just fmt-check`, `just clippy` all clean on this branch), and any merge order is conflict-free.

Both fixes were found while running real published Pine strategies through pinecone bar-by-bar.

## 1. `fix(parser)`: consume dangling Dedents between call arguments

A named argument whose value wraps onto an indented continuation line (the common `table.cell(..., bgcolor = cond ? a :\n<indent>b, ...)` idiom) leaves a closing `Dedent` in the token stream after the comma. `arguments()` only skipped `Newline`+`Indent` there, so the *next* argument failed to parse. The fix consumes such Dedents after a comma, guarded so the argument list's own closing Dedent (immediately followed by `RParen`) is preserved.

**Test:** multiline-ternary named argument followed by another argument — fails to parse before the fix.

## 2. `feat(lexer)`: Pine's line-wrapping rule

Per the Pine Script reference ([Line wrapping](https://www.tradingview.com/pine-script-docs/writing/style-guide/#line-wrapping)), a statement may wrap onto following lines as long as the continuation's indentation is **not a multiple of 4 spaces** — multiples of 4 are reserved for delimiting local blocks. The lexer treated every deeper line start as `Indent`, so this canonical published-script style failed with `Unexpected token: And`:

```pine
can_trade = trades_this_day < 2
         and under_profit_cap
         and above_loss_limit
```

The fix: at line start, when the indentation is not a multiple of 4, join the line to the previous logical line (drop the `Newline` that ended it; leave the indent stack untouched). The existing testdata corpus contains no non-multiple-of-4 indentation, so its behavior is unchanged — verified by the full suite.

**Tests:** lexer token-stream tests (a wrapped continuation emits no `Indent`/`Dedent` and no `Newline` before the continuation's operator; a 4-space block still emits `Indent`/`Dedent`), plus parser tests for a wrapped `and`-chain and a wrapped ternary inside an `if` block.

Note: the two commits are ordered — the lexer commit's parser tests build on the Dedent fix — so they travel together in this PR.

## Validation

Beyond the tests in this PR, the combined change set (this PR plus its two siblings from #49) was validated externally: we run full Pine strategies through pinecone one bar at a time and diff the emitted entries/exits against TradingView's own strategy-tester CSV export for the same symbol/timeframe. With all of them in place, two real strategies match TV 100% — 56/56 signals on a 4H strategy and 21/21 on a daily strategy, including exit-reason order comments — over their full comparison windows.
