### PR TITLE
feat(lexer): allow any indentation for lines wrapped inside parentheses

### DIFF
--- a/crates/pine-lexer/src/lib.rs
+++ b/crates/pine-lexer/src/lib.rs
@@ -116,6 +116,7 @@ pub struct Lexer {
     column: usize,
     indent_stack: Vec<usize>,   // Stack of indentation levels
     pending_tokens: Vec<Token>, // Queue for Indent/Dedent tokens
+    paren_depth: usize,         // Open parentheses; while > 0, layout tokens are suppressed
 }
 
 impl Lexer {
@@ -127,6 +128,7 @@ impl Lexer {
             column: 1,
             indent_stack: vec![0], // Start with base indentation level
             pending_tokens: vec![],
+            paren_depth: 0,
         }
     }
 
@@ -714,7 +716,13 @@ impl Lexer {
                     break;
                 }
 
-                if indent_level % 4 != 0 {
+                if self.paren_depth > 0 {
+                    // Inside parentheses, Pine allows a wrapped line to use any
+                    // indentation, including a multiple of 4. Ignore this line's
+                    // indentation entirely: emit no Indent/Dedent and leave the
+                    // indent stack untouched. The Newline that would have ended
+                    // the previous line is suppressed where it is produced.
+                } else if indent_level % 4 != 0 {
                     // Pine line-wrapping: a line indented by a non-multiple of
                     // 4 spaces continues the previous logical line (Pine
                     // reserves 4-space multiples for local blocks). Join it to
@@ -772,10 +780,23 @@ impl Lexer {
             // Get next token
             let token = self.next_token()?;
 
+            // Track parenthesis nesting so layout tokens can be suppressed
+            // inside a parenthesised expression (Pine line-wrapping rule).
+            match token.typ {
+                TokenType::LParen => self.paren_depth += 1,
+                TokenType::RParen => self.paren_depth = self.paren_depth.saturating_sub(1),
+                _ => {}
+            }
+
             // Check if this is a newline
             if matches!(token.typ, TokenType::Newline) {
                 at_line_start = true;
-                tokens.push(token);
+                // Inside parentheses a newline does not terminate the logical
+                // line, so drop it; the following line's indentation is ignored
+                // by the layout block above.
+                if self.paren_depth == 0 {
+                    tokens.push(token);
+                }
             } else if matches!(token.typ, TokenType::Eof) {
                 // Emit dedents for all remaining levels
                 while self.indent_stack.len() > 1 {
@@ -849,6 +870,35 @@ mod tests {
             tokens.iter().any(|t| matches!(t.typ, TokenType::Dedent)),
             "return to column 0 must still emit Dedent"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parens_suppress_layout_at_any_indent() -> eyre::Result<()> {
+        // Inside parentheses a wrapped line may use any indentation, including a
+        // multiple of 4. The whole call is one logical line: no Newline, Indent
+        // or Dedent appears between `(` and `)`.
+        let mut lexer = Lexer::new("plot(\n    a,\n        b\n)");
+        let tokens = lexer.tokenize()?;
+        assert!(matches!(&tokens[0].typ, TokenType::Ident(s) if s == "plot"));
+        assert!(matches!(tokens[1].typ, TokenType::LParen));
+        assert!(matches!(&tokens[2].typ, TokenType::Ident(s) if s == "a"));
+        assert!(matches!(tokens[3].typ, TokenType::Comma));
+        assert!(matches!(&tokens[4].typ, TokenType::Ident(s) if s == "b"));
+        assert!(matches!(tokens[5].typ, TokenType::RParen));
+        assert!(matches!(tokens[6].typ, TokenType::Eof));
+        Ok(())
+    }
+
+    #[test]
+    fn test_newline_after_closing_paren_terminates() -> eyre::Result<()> {
+        // The Newline after the closing paren still terminates the statement,
+        // so a following statement stays separate.
+        let mut lexer = Lexer::new("x = f(\n    a\n)\ny = 1");
+        let tokens = lexer.tokenize()?;
+        assert!(matches!(tokens[5].typ, TokenType::RParen));
+        assert!(matches!(tokens[6].typ, TokenType::Newline));
+        assert!(matches!(&tokens[7].typ, TokenType::Ident(s) if s == "y"));
         Ok(())
     }
 

--- a/crates/pine-parser/src/lib.rs
+++ b/crates/pine-parser/src/lib.rs
@@ -1497,9 +1497,6 @@ impl Parser {
     fn arguments(&mut self) -> Result<Vec<Argument>, ParserError> {
         let mut args = vec![];
 
-        // Skip leading newlines in argument list
-        self.skip_newlines_and_indent();
-
         if !self.check(&TokenType::RParen) {
             loop {
                 // Check for named argument: name=value
@@ -1531,43 +1528,11 @@ impl Parser {
                     args.push(Argument::Positional(expr));
                 }
 
-                // Skip newlines after each argument
-                self.skip_newlines();
-
                 if !self.match_token(&[TokenType::Comma]) {
                     break;
                 }
-
-                // Skip newlines after comma. The previous argument's value may have
-                // used an indented continuation (multiline ternary), leaving a closing
-                // Dedent in the stream before the next argument. Consume any such
-                // Dedents, then consume an optional Indent if the next argument is
-                // itself on an indented line.
-                self.skip_newlines();
-                while self.check(&TokenType::Dedent) {
-                    // Only consume Dedents that are not the argument list's own
-                    // closing Dedent (which would be immediately followed by RParen).
-                    let consumed = self.try_parse(|p| {
-                        p.advance(); // consume Dedent
-                        if p.check(&TokenType::RParen) {
-                            Err(ParserError::UnexpectedToken(
-                                p.peek().typ.clone(),
-                                p.peek().line,
-                            ))
-                        } else {
-                            Ok(())
-                        }
-                    });
-                    if consumed.is_none() {
-                        break;
-                    }
-                }
-                self.match_token(&[TokenType::Indent]);
             }
         }
-
-        // Skip trailing newlines and dedent before closing paren
-        self.skip_newlines_and_dedent();
 
         Ok(args)
     }

--- a/crates/pine-parser/testdata/syntax/wrap_call_consistent_4space.pine
+++ b/crates/pine-parser/testdata/syntax/wrap_call_consistent_4space.pine
@@ -1,0 +1,10 @@
+//@version=6
+
+// The recommended consistent style: one argument per wrapped line, each
+// indented by 4 spaces, with the closing parenthesis on its own line. A
+// 4-space indent inside parentheses does not open a block.
+lengthInput = input.int(
+    defval = 10,
+    title = "Show last",
+    minval = 1
+)

--- a/crates/pine-parser/testdata/syntax/wrap_call_consistent_4space_ast.json
+++ b/crates/pine-parser/testdata/syntax/wrap_call_consistent_4space_ast.json
@@ -1,0 +1,53 @@
+[
+  {
+    "VarDecl": {
+      "name": "lengthInput",
+      "type_annotation": null,
+      "initializer": {
+        "Call": {
+          "callee": {
+            "MemberAccess": {
+              "object": {
+                "Variable": "input"
+              },
+              "member": "int"
+            }
+          },
+          "args": [
+            {
+              "Named": {
+                "name": "defval",
+                "value": {
+                  "Literal": {
+                    "Number": 10.0
+                  }
+                }
+              }
+            },
+            {
+              "Named": {
+                "name": "title",
+                "value": {
+                  "Literal": {
+                    "String": "Show last"
+                  }
+                }
+              }
+            },
+            {
+              "Named": {
+                "name": "minval",
+                "value": {
+                  "Literal": {
+                    "Number": 1.0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "is_varip": false
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/wrap_call_escalating_indent.pine
+++ b/crates/pine-parser/testdata/syntax/wrap_call_escalating_indent.pine
@@ -1,0 +1,9 @@
+//@version=6
+
+// A wrapped argument indented deeper than the previous one (4 then 8 spaces)
+// inside a call. Both indents are multiples of 4, which at top level would open
+// nested blocks; inside parentheses they are just continuation lines.
+x = f(
+    a,
+        b
+)

--- a/crates/pine-parser/testdata/syntax/wrap_call_escalating_indent_ast.json
+++ b/crates/pine-parser/testdata/syntax/wrap_call_escalating_indent_ast.json
@@ -1,0 +1,28 @@
+[
+  {
+    "VarDecl": {
+      "name": "x",
+      "type_annotation": null,
+      "initializer": {
+        "Call": {
+          "callee": {
+            "Variable": "f"
+          },
+          "args": [
+            {
+              "Positional": {
+                "Variable": "a"
+              }
+            },
+            {
+              "Positional": {
+                "Variable": "b"
+              }
+            }
+          ]
+        }
+      },
+      "is_varip": false
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/wrap_call_mixed_indent.pine
+++ b/crates/pine-parser/testdata/syntax/wrap_call_mixed_indent.pine
@@ -1,0 +1,12 @@
+//@version=6
+
+// Pine line wrapping: inside a function call's parentheses, each wrapped line
+// may use ANY indentation (here 1, 3, 4 and 8 spaces), including multiples of
+// 4. The whole call is a single logical line. Trailing comments on wrapped
+// lines are allowed. (From the TradingView "Line wrapping" reference.)
+plot(
+ percentChange, title = "Percent change",
+   color = (percentChange >= 0 ? color.green : color.red),
+    linewidth = 8,
+        style = plot.style_histogram, format = format.percent
+)

--- a/crates/pine-parser/testdata/syntax/wrap_call_mixed_indent_ast.json
+++ b/crates/pine-parser/testdata/syntax/wrap_call_mixed_indent_ast.json
@@ -1,0 +1,102 @@
+[
+  {
+    "Expression": {
+      "Call": {
+        "callee": {
+          "Variable": "plot"
+        },
+        "args": [
+          {
+            "Positional": {
+              "Variable": "percentChange"
+            }
+          },
+          {
+            "Named": {
+              "name": "title",
+              "value": {
+                "Literal": {
+                  "String": "Percent change"
+                }
+              }
+            }
+          },
+          {
+            "Named": {
+              "name": "color",
+              "value": {
+                "Ternary": {
+                  "condition": {
+                    "Binary": {
+                      "left": {
+                        "Variable": "percentChange"
+                      },
+                      "op": "GreaterEq",
+                      "right": {
+                        "Literal": {
+                          "Number": 0.0
+                        }
+                      }
+                    }
+                  },
+                  "then_expr": {
+                    "MemberAccess": {
+                      "object": {
+                        "Variable": "color"
+                      },
+                      "member": "green"
+                    }
+                  },
+                  "else_expr": {
+                    "MemberAccess": {
+                      "object": {
+                        "Variable": "color"
+                      },
+                      "member": "red"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "Named": {
+              "name": "linewidth",
+              "value": {
+                "Literal": {
+                  "Number": 8.0
+                }
+              }
+            }
+          },
+          {
+            "Named": {
+              "name": "style",
+              "value": {
+                "MemberAccess": {
+                  "object": {
+                    "Variable": "plot"
+                  },
+                  "member": "style_histogram"
+                }
+              }
+            }
+          },
+          {
+            "Named": {
+              "name": "format",
+              "value": {
+                "MemberAccess": {
+                  "object": {
+                    "Variable": "format"
+                  },
+                  "member": "percent"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/wrap_call_nested.pine
+++ b/crates/pine-parser/testdata/syntax/wrap_call_nested.pine
@@ -1,0 +1,11 @@
+//@version=6
+
+// Nested calls wrapped across lines: closing the inner parenthesis does not end
+// the outer call's line. The whole expression is one logical line regardless of
+// the varied indentation at each level.
+x = f(
+    g(
+        1
+    ),
+    2
+)

--- a/crates/pine-parser/testdata/syntax/wrap_call_nested_ast.json
+++ b/crates/pine-parser/testdata/syntax/wrap_call_nested_ast.json
@@ -1,0 +1,43 @@
+[
+  {
+    "VarDecl": {
+      "name": "x",
+      "type_annotation": null,
+      "initializer": {
+        "Call": {
+          "callee": {
+            "Variable": "f"
+          },
+          "args": [
+            {
+              "Positional": {
+                "Call": {
+                  "callee": {
+                    "Variable": "g"
+                  },
+                  "args": [
+                    {
+                      "Positional": {
+                        "Literal": {
+                          "Number": 1.0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "Positional": {
+                "Literal": {
+                  "Number": 2.0
+                }
+              }
+            }
+          ]
+        }
+      },
+      "is_varip": false
+    }
+  }
+]

--- a/crates/pine-parser/testdata/syntax/wrap_paren_expression_4space.pine
+++ b/crates/pine-parser/testdata/syntax/wrap_paren_expression_4space.pine
@@ -1,0 +1,8 @@
+//@version=6
+
+// A wrapped expression enclosed in parentheses (not a call) may also use
+// 4-space indentation. The parentheses, not the indentation, group the
+// expression across lines.
+percentChange = (
+    (closeDiff)
+    / close[1] * 100  )

--- a/crates/pine-parser/testdata/syntax/wrap_paren_expression_4space_ast.json
+++ b/crates/pine-parser/testdata/syntax/wrap_paren_expression_4space_ast.json
@@ -1,0 +1,39 @@
+[
+  {
+    "VarDecl": {
+      "name": "percentChange",
+      "type_annotation": null,
+      "initializer": {
+        "Binary": {
+          "left": {
+            "Binary": {
+              "left": {
+                "Variable": "closeDiff"
+              },
+              "op": "Div",
+              "right": {
+                "Index": {
+                  "expr": {
+                    "Variable": "close"
+                  },
+                  "index": {
+                    "Literal": {
+                      "Number": 1.0
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "op": "Mul",
+          "right": {
+            "Literal": {
+              "Number": 100.0
+            }
+          }
+        }
+      },
+      "is_varip": false
+    }
+  }
+]


### PR DESCRIPTION
Followup on #50.

Inside a parenthesis, a wrapped line can use any level of indentation. 