### PR TITLE
Enable version 5 scripts in corpus

### DIFF
--- a/crates/pine-builtins/src/constants/mod.rs
+++ b/crates/pine-builtins/src/constants/mod.rs
@@ -8,6 +8,8 @@
 pub mod display;
 pub mod format;
 pub mod location;
+pub mod order;
 pub mod position;
 pub mod shape;
 pub mod size;
+pub mod text;

--- a/crates/pine-builtins/src/constants/order.rs
+++ b/crates/pine-builtins/src/constants/order.rs
@@ -1,0 +1,22 @@
+use pine_interpreter::{PineOutput, Value};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// The `order.*` constants (sort direction for `array.sort`, matrix ops, ...).
+const ORDERS: &[&str] = &["ascending", "descending", "alert", "alert_message"];
+
+/// Register the order namespace with all order constants.
+pub fn register<O: PineOutput>() -> Value<O> {
+    let mut members: HashMap<String, Value<O>> = HashMap::new();
+
+    for order in ORDERS {
+        members.insert(order.to_string(), Value::String(order.to_string()));
+    }
+
+    Value::Object {
+        type_name: "order".to_string(),
+        fields: Rc::new(RefCell::new(members)),
+        call: None,
+    }
+}

--- a/crates/pine-builtins/src/constants/text.rs
+++ b/crates/pine-builtins/src/constants/text.rs
@@ -1,0 +1,30 @@
+use pine_interpreter::{PineOutput, Value};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// The `text.*` constants (text alignment and wrapping for labels/tables/boxes).
+const TEXTS: &[&str] = &[
+    "align_left",
+    "align_center",
+    "align_right",
+    "align_top",
+    "align_bottom",
+    "wrap_none",
+    "wrap_auto",
+];
+
+/// Register the text namespace with all text constants.
+pub fn register<O: PineOutput>() -> Value<O> {
+    let mut members: HashMap<String, Value<O>> = HashMap::new();
+
+    for text in TEXTS {
+        members.insert(text.to_string(), Value::String(text.to_string()));
+    }
+
+    Value::Object {
+        type_name: "text".to_string(),
+        fields: Rc::new(RefCell::new(members)),
+        call: None,
+    }
+}

--- a/crates/pine-builtins/src/indicator/mod.rs
+++ b/crates/pine-builtins/src/indicator/mod.rs
@@ -5,6 +5,7 @@
 //! [`IndicatorOutput`]; a script may have at most one (enforced by sema).
 
 use pine_builtin_macro::BuiltinFunction;
+use pine_core::PineVersion;
 use pine_interpreter::{Indicator, IndicatorOutput, Interpreter, PineOutput, RuntimeError, Value};
 use std::rc::Rc;
 
@@ -60,7 +61,14 @@ impl IndicatorFn {
     }
 }
 
-/// The `indicator` global function value.
-pub fn register<O: PineOutput + IndicatorOutput>() -> Value<O> {
-    Value::BuiltinFunction(Rc::new(IndicatorFn::builtin_fn::<O>))
+pub fn register<O: PineOutput + IndicatorOutput>(version: PineVersion) -> Vec<(String, Value<O>)> {
+    let name = if version < PineVersion::V5 {
+        "study"
+    } else {
+        "indicator"
+    };
+    vec![(
+        name.to_string(),
+        Value::BuiltinFunction(Rc::new(IndicatorFn::builtin_fn::<O>)),
+    )]
 }

--- a/crates/pine-builtins/src/lib.rs
+++ b/crates/pine-builtins/src/lib.rs
@@ -227,6 +227,8 @@ pub fn register_namespace_objects<
     namespaces.insert("position".to_string(), constants::position::register());
     namespaces.insert("display".to_string(), constants::display::register());
     namespaces.insert("format".to_string(), constants::format::register());
+    namespaces.insert("order".to_string(), constants::order::register());
+    namespaces.insert("text".to_string(), constants::text::register());
     namespaces.insert("log".to_string(), log::register());
     namespaces.insert("math".to_string(), math::register());
     namespaces.insert("matrix".to_string(), matrix::register());

--- a/crates/pine-builtins/src/lib.rs
+++ b/crates/pine-builtins/src/lib.rs
@@ -213,7 +213,9 @@ pub fn register_namespace_objects<
         namespaces.insert(name, value);
     }
     namespaces.insert("table".to_string(), table::register());
-    namespaces.insert("indicator".to_string(), indicator::register());
+    for (name, value) in indicator::register(version) {
+        namespaces.insert(name, value);
+    }
     namespaces.insert("alertcondition".to_string(), alertcondition::register());
     namespaces.insert("fill".to_string(), fill::register());
     for (name, value) in globals::register() {
@@ -230,10 +232,16 @@ pub fn register_namespace_objects<
     namespaces.insert("order".to_string(), constants::order::register());
     namespaces.insert("text".to_string(), constants::text::register());
     namespaces.insert("log".to_string(), log::register());
-    namespaces.insert("math".to_string(), math::register());
+    for (name, func) in math::register(version) {
+        namespaces.insert(name, func);
+    }
     namespaces.insert("matrix".to_string(), matrix::register());
-    namespaces.insert("str".to_string(), str::register());
-    namespaces.insert("ta".to_string(), ta::register());
+    for (name, func) in str::register(version) {
+        namespaces.insert(name, func);
+    }
+    for (name, func) in ta::register(version) {
+        namespaces.insert(name, func);
+    }
 
     // Register global builtin functions
     namespaces.insert(

--- a/crates/pine-builtins/src/math/mod.rs
+++ b/crates/pine-builtins/src/math/mod.rs
@@ -1,5 +1,9 @@
 use pine_builtin_macro::BuiltinFunction;
+use pine_core::PineVersion;
 use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
 
 /// math.abs(number) - Returns absolute value
 #[derive(BuiltinFunction)]
@@ -434,11 +438,7 @@ impl MathRandom {
 }
 
 /// Register all math namespace functions and return the namespace object
-pub fn register<O: PineOutput>() -> Value<O> {
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-    use std::rc::Rc;
-
+pub fn register<O: PineOutput>(version: PineVersion) -> HashMap<String, Value<O>> {
     let mut math_ns: HashMap<String, Value<O>> = HashMap::new();
 
     // Single-argument functions
@@ -543,9 +543,18 @@ pub fn register<O: PineOutput>() -> Value<O> {
         Value::BuiltinFunction(Rc::new(MathRandom::builtin_fn::<O>)),
     );
 
-    Value::Object {
-        type_name: "math".to_string(),
-        fields: Rc::new(RefCell::new(math_ns)),
-        call: None,
+    if matches!(version, PineVersion::V5 | PineVersion::V6) {
+        let mut obj: HashMap<String, Value<O>> = HashMap::new();
+        obj.insert(
+            "math".to_string(),
+            Value::Object {
+                type_name: "math".to_string(),
+                fields: Rc::new(RefCell::new(math_ns)),
+                call: None,
+            },
+        );
+        obj
+    } else {
+        math_ns
     }
 }

--- a/crates/pine-builtins/src/str/mod.rs
+++ b/crates/pine-builtins/src/str/mod.rs
@@ -1,6 +1,8 @@
 use pine_builtin_macro::BuiltinFunction;
+use pine_core::PineVersion;
 use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 /// str.length(string) - Returns the length of a string
@@ -267,10 +269,8 @@ impl StrRepeat {
 }
 
 /// Register all str namespace functions and return the namespace object
-pub fn register<O: PineOutput>() -> Value<O> {
-    use std::cell::RefCell;
-
-    let mut str_ns: std::collections::HashMap<String, Value<O>> = std::collections::HashMap::new();
+pub fn register<O: PineOutput>(version: PineVersion) -> HashMap<String, Value<O>> {
+    let mut str_ns: HashMap<String, Value<O>> = std::collections::HashMap::new();
 
     str_ns.insert(
         "length".to_string(),
@@ -329,9 +329,18 @@ pub fn register<O: PineOutput>() -> Value<O> {
         Value::BuiltinFunction(Rc::new(StrRepeat::builtin_fn::<O>)),
     );
 
-    Value::Object {
-        type_name: "str".to_string(),
-        fields: Rc::new(RefCell::new(str_ns)),
-        call: None,
+    if matches!(version, PineVersion::V5 | PineVersion::V6) {
+        let mut obj: HashMap<String, Value<O>> = HashMap::new();
+        obj.insert(
+            "str".to_string(),
+            Value::Object {
+                type_name: "str".to_string(),
+                fields: Rc::new(RefCell::new(str_ns)),
+                call: None,
+            },
+        );
+        obj
+    } else {
+        str_ns
     }
 }

--- a/crates/pine-builtins/src/ta/mod.rs
+++ b/crates/pine-builtins/src/ta/mod.rs
@@ -1,5 +1,7 @@
+use pine_core::PineVersion;
 use pine_interpreter::{PineOutput, Value};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 mod comparison;
@@ -15,8 +17,8 @@ pub use statistics::*;
 pub use volatility::*;
 
 /// Register all ta namespace functions and return the namespace object
-pub fn register<O: PineOutput>() -> Value<O> {
-    let mut ta_ns: std::collections::HashMap<String, Value<O>> = std::collections::HashMap::new();
+pub fn register<O: PineOutput>(version: PineVersion) -> HashMap<String, Value<O>> {
+    let mut ta_ns: HashMap<String, Value<O>> = HashMap::new();
 
     // Moving averages
     ta_ns.insert(
@@ -148,9 +150,18 @@ pub fn register<O: PineOutput>() -> Value<O> {
         Value::BuiltinFunction(Rc::new(TaLinreg::<O>::builtin_fn)),
     );
 
-    Value::Object {
-        type_name: "ta".to_string(),
-        fields: Rc::new(RefCell::new(ta_ns)),
-        call: None,
+    if matches!(version, PineVersion::V5 | PineVersion::V6) {
+        let mut obj: HashMap<String, Value<O>> = HashMap::new();
+        obj.insert(
+            "ta".to_string(),
+            Value::Object {
+                type_name: "ta".to_string(),
+                fields: Rc::new(RefCell::new(ta_ns)),
+                call: None,
+            },
+        );
+        obj
+    } else {
+        ta_ns
     }
 }

--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -84,6 +84,7 @@ pub struct Bar {
     pub low: f64,
     pub close: f64,
     pub volume: f64,
+    pub index: u64,
     /// The bar's opening time as a UNIX timestamp in milliseconds, exposed to
     /// scripts as the `time` variable.
     pub time: i64,

--- a/crates/pine-sema/src/analyzer.rs
+++ b/crates/pine-sema/src/analyzer.rs
@@ -32,7 +32,7 @@ pub struct Analyzer<'a, O: PineOutput> {
 }
 
 /// The script-declaration functions — a script must have exactly one.
-const SCRIPT_DECLARATIONS: &[&str] = &["indicator", "strategy", "library"];
+const SCRIPT_DECLARATIONS: &[&str] = &["study", "indicator", "strategy", "library"];
 
 impl<'a, O: PineOutput> Analyzer<'a, O> {
     pub fn new(builtins: &'a HashMap<String, Value<O>>) -> Self {

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -168,7 +168,16 @@ impl<O: PineOutput> ScriptBuilder<O> {
         for (name, value) in pine_builtins::register_per_bar(&Bar::default()) {
             builtins.insert(name, value);
         }
-        for name in ["open", "high", "low", "close", "volume", "ohlc4", "hl2"] {
+        for name in [
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "ohlc4",
+            "hl2",
+            "bar_index",
+        ] {
             builtins.insert(name.to_string(), Value::Na);
         }
         for (name, value) in &self.custom_variables {
@@ -255,6 +264,8 @@ impl<O: PineOutput> Script<O> {
                 current: Box::new(Value::Number(bar.volume)),
             }),
         );
+        self.interpreter
+            .set_variable("bar_index", Value::Number(bar.index as f64));
 
         // Per-bar namespaces (barstate) are rebuilt from this bar's flags.
         for (name, value) in pine_builtins::register_per_bar(bar) {

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -66,10 +66,7 @@ fn test_corpus() -> eyre::Result<()> {
             let source = fs::read_to_string(path)?;
 
             let script_version = PineVersion::detect(&source)?.expect("pinescript version");
-            if !matches!(
-                script_version,
-                PineVersion::V6 | PineVersion::V5 | PineVersion::V4
-            ) {
+            if !matches!(script_version, PineVersion::V6 | PineVersion::V5) {
                 continue;
             };
 

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -65,10 +65,10 @@ fn test_corpus() -> eyre::Result<()> {
             let path = entry.path();
             let source = fs::read_to_string(path)?;
 
-            // Only v6 is supported for now.
-            if PineVersion::detect(&source) != Ok(Some(PineVersion::V6)) {
+            let script_version = PineVersion::detect(&source)?.expect("pinescript version");
+            if !matches!(script_version, PineVersion::V6 | PineVersion::V5) {
                 continue;
-            }
+            };
 
             let relative_path = path.strip_prefix(&corpus_dir).unwrap_or(path);
             match ScriptBuilder::<DefaultPineOutput>::with_code(&source).compile() {

--- a/tests/corpus.rs
+++ b/tests/corpus.rs
@@ -66,7 +66,10 @@ fn test_corpus() -> eyre::Result<()> {
             let source = fs::read_to_string(path)?;
 
             let script_version = PineVersion::detect(&source)?.expect("pinescript version");
-            if !matches!(script_version, PineVersion::V6 | PineVersion::V5) {
+            if !matches!(
+                script_version,
+                PineVersion::V6 | PineVersion::V5 | PineVersion::V4
+            ) {
                 continue;
             };
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -26,6 +26,7 @@ mod tests {
                 low: base - 5.0,
                 close: base + 2.0,
                 volume: 1000.0 + (i as f64 * 10.0),
+                index: i as u64,
                 // A distinct per-bar timestamp so the `time` fixture can assert it.
                 time: (i as i64) * 1000,
                 // Dummy barstate

--- a/tests/testdata/builtins/input_v3.pine
+++ b/tests/testdata/builtins/input_v3.pine
@@ -1,18 +1,12 @@
 //@version=3
 // v3 input(): the type is an argument given as a bare constant (`type=integer`).
-// `input` returns the default; type/minval/options are accepted and ignored.
+//
+// v3 has no `log.*` namespace — bare `log` is math's natural logarithm — so this
+// fixture can't print. It asserts the v3 syntax compiles and runs cleanly; the
+// returned values are asserted in input_v5.pine.
 length = input(14, "Length", type=integer, minval=1)
 factor = input(2.5, "Factor", type=float)
 useClose = input(true, "Use Close", type=bool)
 maType = input("EMA", "MA Type", options=["EMA", "SMA"])
 
-log.info(length)
-log.info(factor)
-log.info(useClose)
-log.info(maType)
-
 // Expected output:
-// 14
-// 2.5
-// true
-// EMA

--- a/tests/testdata/builtins/input_v4.pine
+++ b/tests/testdata/builtins/input_v4.pine
@@ -1,18 +1,13 @@
 //@version=4
 // v4 input(): same overloaded `input()`, but the type is a namespaced constant
-// (`type=input.integer`). Returns the default; type/minval/options are ignored.
+// (`type=input.integer`).
+//
+// v4 has no `log.*` namespace — bare `log` is math's natural logarithm — so this
+// fixture can't print. It asserts the v4 syntax compiles and runs cleanly; the
+// returned values are asserted in input_v5.pine.
 length = input(14, "Length", type=input.integer, minval=1)
 factor = input(2.5, "Factor", type=input.float)
 useClose = input(true, "Use Close", type=input.bool)
 maType = input("EMA", "MA Type", options=["EMA", "SMA"])
 
-log.info(length)
-log.info(factor)
-log.info(useClose)
-log.info(maType)
-
 // Expected output:
-// 14
-// 2.5
-// true
-// EMA

--- a/tests/testdata/constants/order.pine
+++ b/tests/testdata/constants/order.pine
@@ -1,0 +1,7 @@
+// order.* constants resolve to their string tag.
+log.info(order.ascending)
+log.info(order.descending)
+
+// Expected output:
+// ascending
+// descending

--- a/tests/testdata/constants/text.pine
+++ b/tests/testdata/constants/text.pine
@@ -1,0 +1,11 @@
+// text.* constants resolve to their string tag.
+log.info(text.align_left)
+log.info(text.align_center)
+log.info(text.align_right)
+log.info(text.wrap_auto)
+
+// Expected output:
+// align_left
+// align_center
+// align_right
+// wrap_auto

--- a/tests/testdata/line/hline_v4.pine
+++ b/tests/testdata/line/hline_v4.pine
@@ -1,10 +1,10 @@
 //@version=4
 // v4 hline: the linestyle is a bare constant (`linestyle=dotted`), not
-// `hline.style_dotted`. Still recorded into the line sink.
-h = hline(0, title="Zero Level", linestyle=dotted)
-log.info(line.get_y1(h))
-log.info(line.get_y2(h))
+// `hline.style_dotted`.
+//
+// v4 has no `log.*` namespace — bare `log` is math's natural logarithm — so this
+// fixture can't print. It asserts the v4 syntax compiles and runs cleanly; the
+// recorded values are asserted in hline.pine.
+h = hline(0, title = "Zero Level", linestyle = dotted)
 
 // Expected output:
-// 0
-// 0


### PR DESCRIPTION
Enable version 5 scripts in the corpus + a few fixes to enable version 4 scripts.