### PR TITLE
Interpreter: don't freeze bar builtins read inside a user function

### DIFF
--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -397,6 +397,53 @@ pub struct Interpreter<O: PineOutput> {
     current_call_id: u32,
 }
 
+/// Names a statement block ASSIGNS (declares or writes) directly — i.e. the true
+/// locals of a function body. Reads (e.g. `open`) are ignored, and nested function
+/// declarations are a separate scope so their bodies are not descended into. Used to
+/// decide which variables a call site's persistent state should carry across bars.
+fn collect_assigned_names(body: &[Stmt], out: &mut std::collections::HashSet<String>) {
+    for s in body {
+        match s {
+            Stmt::VarDecl { name, .. } => {
+                out.insert(name.clone());
+            }
+            Stmt::Assignment {
+                target: Expr::Variable(n),
+                ..
+            } => {
+                out.insert(n.clone());
+            }
+            Stmt::TupleAssignment { names, .. } => {
+                for n in names {
+                    out.insert(n.clone());
+                }
+            }
+            Stmt::If {
+                then_branch,
+                else_if_branches,
+                else_branch,
+                ..
+            } => {
+                collect_assigned_names(then_branch, out);
+                for (_, b) in else_if_branches {
+                    collect_assigned_names(b, out);
+                }
+                if let Some(b) = else_branch {
+                    collect_assigned_names(b, out);
+                }
+            }
+            Stmt::For { var_name, body, .. } => {
+                out.insert(var_name.clone());
+                collect_assigned_names(body, out);
+            }
+            Stmt::While { body, .. } | Stmt::ForIn { body, .. } => {
+                collect_assigned_names(body, out)
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Pine `na` is float NaN. NaN can also reach `==`/`!=` wrapped as a
 /// `Value::Number(NaN)` (ta.* functions return `Number(NaN)` for all-NaN
 /// windows) rather than `Value::Na` — both forms make the comparison yield na.
@@ -1802,9 +1849,17 @@ impl<O: PineOutput> Interpreter<O> {
         // outer/global scope, so two call sites keep independent state.
         let call_vars = std::mem::replace(&mut self.variables, saved_vars);
         if call_id != 0 {
+            // Persist only the names the body actually ASSIGNS — its true locals
+            // (both `var` and plain, so their series history advances). The scope
+            // also holds read-only builtins/globals inherited from the outer scope
+            // (`open`/`high`/`low`/`close`/…); saving one of those would restore it
+            // stale on the next call, freezing any indicator that reads it inside
+            // the function (e.g. a recursive Heikin-Ashi open).
+            let mut assigned: std::collections::HashSet<String> = std::collections::HashSet::new();
+            collect_assigned_names(body, &mut assigned);
             let local_state: HashMap<String, Variable<O>> = call_vars
                 .into_iter()
-                .filter(|(k, _)| !param_names.contains(k))
+                .filter(|(k, _)| !param_names.contains(k) && assigned.contains(k))
                 .collect();
             self.function_local_state.insert(call_id, local_state);
         }

--- a/tests/testdata/functions/function_local_bar_builtin_not_frozen.pine
+++ b/tests/testdata/functions/function_local_bar_builtin_not_frozen.pine
@@ -1,0 +1,17 @@
+// A host bar builtin (`open`) read inside a user function must reflect the
+// CURRENT bar on every bar — it must not be frozen at the first call's value.
+// Regression: the call-site local-state save kept every non-parameter name in
+// scope, including inherited builtins like `open`, and restored them stale on
+// the next bar, so any stateful indicator that reads open/high/low/close inside
+// a function (e.g. a recursive Heikin-Ashi open) silently froze.
+
+// Bars: 4
+f() =>
+    open + 10.0
+log.info(f())
+
+// Expected output:
+// 306
+// 307
+// 308
+// 309


### PR DESCRIPTION
## Problem

`run_call_site_body` persists a call site's locals across bars (so series indexing like `o[1]` works inside a function body). But the save kept **every** non-parameter name left in the scope after the body ran:

```rust
let local_state = call_vars
    .into_iter()
    .filter(|(k, _)| !param_names.contains(k))
    .collect();
```

That scope also contains the read-only **bar builtins** inherited from the outer scope — `open`/`high`/`low`/`close`/`volume`/… , which `Script::execute` rebinds every bar. They got saved into `function_local_state` and **restored stale** on the next call, before the body ran. So any stateful indicator that reads a bar builtin directly inside a function froze at the first call's value.

The classic victim is a recursive Heikin-Ashi open computed inside a function: it reads `open`/`close` each bar, so from the second bar on it silently used bar-0 prices.

## Fix

Persist only the names the body actually **assigns** — its true locals (both `var` and plain, so their `[n]` series history still advances) — never the inherited builtins:

```rust
let mut assigned = HashSet::new();
collect_assigned_names(body, &mut assigned);
let local_state = call_vars
    .into_iter()
    .filter(|(k, _)| !param_names.contains(k) && assigned.contains(k))
    .collect();
```

`collect_assigned_names` walks the body for `VarDecl` / `Assignment(Variable)` / `TupleAssignment` / `for` targets, and does **not** descend into nested function declarations (a separate scope). `var` persistence and per-call-site independence are unchanged.

## Test

`tests/testdata/functions/function_local_bar_builtin_not_frozen.pine` — `open + 10` read inside a function must track the current bar over 4 bars (`306, 307, 308, 309`). Before the fix it produces `306, 306, 306, 306`. The existing `function_local_var_persists` / `function_state_per_call_site` corpus tests stay green (they guard against over-filtering).

## How it was found

Discovered downstream while validating a multi-timeframe Heikin-Ashi strategy against TradingView's Strategy Tester bar-for-bar: the recursive HA open (a stateful function reading `open`/`close`) was frozen, which this fixes.
