### PR TITLE
Accumulative builtins

### DIFF
--- a/benches/src/test_data.rs
+++ b/benches/src/test_data.rs
@@ -1,7 +1,6 @@
 use pine::ScriptBuilder;
 use pine_builtins::DefaultPineOutput;
-use pine_interpreter::{Bar, HistoricalDataProvider, Value};
-use std::cell::Cell;
+use pine_interpreter::Bar;
 
 /// Generate synthetic OHLCV bar data for benchmarking
 pub fn generate_bars(count: usize) -> Vec<Bar> {
@@ -36,62 +35,12 @@ pub fn generate_bars(count: usize) -> Vec<Bar> {
     bars
 }
 
-/// Mock historical data provider for benchmarks
-pub struct BenchHistoricalData {
-    bars: Vec<Bar>,
-    current_index: Cell<usize>,
-}
-
-impl BenchHistoricalData {
-    pub fn new(bars: Vec<Bar>) -> Self {
-        Self {
-            bars,
-            current_index: Cell::new(0),
-        }
-    }
-
-    pub fn set_current_bar(&self, index: usize) {
-        self.current_index.set(index);
-    }
-}
-
-impl HistoricalDataProvider for BenchHistoricalData {
-    fn get_historical(&self, series_id: &str, offset: usize) -> Option<Value<DefaultPineOutput>> {
-        let current_index = self.current_index.get();
-
-        if current_index < offset {
-            return None;
-        }
-
-        let bar_index = current_index - offset;
-        if bar_index >= self.bars.len() {
-            return None;
-        }
-
-        let bar = &self.bars[bar_index];
-        let value = match series_id {
-            "open" => bar.open,
-            "high" => bar.high,
-            "low" => bar.low,
-            "close" => bar.close,
-            "volume" => bar.volume,
-            _ => return None,
-        };
-
-        Some(Value::Number(value))
-    }
-}
-
-/// Execute a script with historical data context
+/// Compile `source` and run it over every bar.
 ///
-/// This helper compiles a script, sets up the historical data provider,
-/// and executes it with the last bar in the dataset.
+/// Series history and stateful builtins accumulate as bars execute, so a script
+/// that looks back has to be replayed from the start rather than evaluated at a
+/// single bar. This measures the whole replay.
 pub fn execute_with_history(source: &str, bars: &[Bar]) -> Result<(), pine::Error> {
-    let historical_data = BenchHistoricalData::new(bars.to_vec());
-    historical_data.set_current_bar(bars.len() - 1);
-    let mut script = ScriptBuilder::with_code(source)
-        .with_historical_provider(Box::new(historical_data))
-        .compile()?;
-    let _output = script.execute(&bars[bars.len() - 1])?;
-    Ok(())
+    let mut script = ScriptBuilder::<DefaultPineOutput>::with_code(source).compile()?;
+    script.execute_bars(bars)
 }

--- a/crates/pine-builtin-macro/src/lib.rs
+++ b/crates/pine-builtin-macro/src/lib.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_macro_input, Data, DeriveInput, Field, Fields, Meta};
 
 /// Derive macro for builtin functions
@@ -30,12 +30,13 @@ use syn::{parse_macro_input, Data, DeriveInput, Field, Fields, Meta};
 ///     }
 /// }
 /// ```
-#[proc_macro_derive(BuiltinFunction, attributes(builtin, arg, type_param))]
+#[proc_macro_derive(BuiltinFunction, attributes(builtin, arg, type_param, state))]
 pub fn builtin_function_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     // Parse the function name and type params count from attributes
-    let (function_name, type_params_count, output_bound) = parse_builtin_attributes(&input);
+    let (function_name, type_params_count, output_bound, stateful) =
+        parse_builtin_attributes(&input);
 
     let struct_name = &input.ident;
 
@@ -86,32 +87,128 @@ pub fn builtin_function_derive(input: TokenStream) -> TokenStream {
         )
     };
 
-    let expanded = quote! {
-        impl #impl_generics #struct_name #ty_generics #where_clause {
-            pub fn builtin_fn #fn_generics (
-                ctx: &mut ::pine_interpreter::Interpreter<O>,
-                call_args: ::pine_interpreter::FunctionCallArgs<O>,
-            ) -> Result<::pine_interpreter::Value<O>, ::pine_interpreter::RuntimeError> {
-                use ::pine_interpreter::{Value, RuntimeError, EvaluatedArg};
+    let body = quote! {
+        // Extract type parameters first
+        #type_param_extraction
 
-                // Extract type parameters first
-                #type_param_extraction
+        let args = call_args.args;
 
-                let args = call_args.args;
+        #field_parsing
 
-                #field_parsing
+        #field_validation
+    };
 
-                #field_validation
+    let expanded = if stateful {
+        let state_fields: Vec<_> = fields.iter().filter(|f| is_field_state(f)).collect();
+        let state_names: Vec<_> = state_fields
+            .iter()
+            .map(|f| f.ident.as_ref().unwrap())
+            .collect();
+        let state_decls: Vec<_> = state_fields
+            .iter()
+            .map(|f| {
+                let name = f.ident.as_ref().unwrap();
+                let ty = &f.ty;
+                quote! { #name: #ty }
+            })
+            .collect();
+        let slot_name = format_ident!("{}Slot", struct_name);
 
-                let instance = Self {
-                    #struct_construction
-                };
-
-                instance.execute(ctx)
+        quote! {
+            /// One call site's memory for the builtin above: its `#[state]`
+            /// fields, plus the bar it last advanced on and what it returned
+            /// then, so re-entering a call site within one bar cannot advance
+            /// the state twice.
+            #[derive(Default)]
+            #[doc(hidden)]
+            pub struct #slot_name<O: ::pine_interpreter::PineOutput> {
+                #(#state_decls,)*
+                bar_seq: u64,
+                memo: Option<::pine_interpreter::Value<O>>,
             }
 
-            pub fn name() -> &'static str {
-                #function_name
+            impl #impl_generics #struct_name #ty_generics #where_clause {
+                /// Builds the callable. Each returned closure owns the state for
+                /// every call site of this builtin, keyed by call id.
+                pub fn builtin_fn #fn_generics () -> ::pine_interpreter::BuiltinFn<O> {
+                    let slots: ::std::rc::Rc<::std::cell::RefCell<
+                        ::std::collections::HashMap<u32, #slot_name<O>>
+                    >> = Default::default();
+
+                    ::std::rc::Rc::new(move |
+                        ctx: &mut ::pine_interpreter::Interpreter<O>,
+                        call_args: ::pine_interpreter::FunctionCallArgs<O>,
+                    | -> Result<::pine_interpreter::Value<O>, ::pine_interpreter::RuntimeError> {
+                        use ::pine_interpreter::{Value, RuntimeError, EvaluatedArg};
+
+                        let call_id = call_args.call_id;
+                        let bar_seq = ctx.bar_seq();
+
+                        // Already ran on this bar: hand back the same value
+                        // rather than advancing the state again.
+                        {
+                            let slots = slots.borrow();
+                            if let Some(slot) = slots.get(&call_id) {
+                                if slot.bar_seq == bar_seq {
+                                    if let Some(memo) = &slot.memo {
+                                        return Ok(memo.clone());
+                                    }
+                                }
+                            }
+                        }
+
+                        #body
+
+                        let mut instance = Self {
+                            #struct_construction
+                        };
+
+                        // Restore what this call site accumulated on earlier bars.
+                        {
+                            let slots = slots.borrow();
+                            if let Some(slot) = slots.get(&call_id) {
+                                #(instance.#state_names = slot.#state_names.clone();)*
+                            }
+                        }
+
+                        let result = instance.execute(ctx)?;
+
+                        let mut slots = slots.borrow_mut();
+                        let slot = slots.entry(call_id).or_default();
+                        #(slot.#state_names = instance.#state_names;)*
+                        slot.bar_seq = bar_seq;
+                        slot.memo = Some(result.clone());
+
+                        Ok(result)
+                    })
+                }
+
+                pub fn name() -> &'static str {
+                    #function_name
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl #impl_generics #struct_name #ty_generics #where_clause {
+                pub fn builtin_fn #fn_generics (
+                    ctx: &mut ::pine_interpreter::Interpreter<O>,
+                    call_args: ::pine_interpreter::FunctionCallArgs<O>,
+                ) -> Result<::pine_interpreter::Value<O>, ::pine_interpreter::RuntimeError> {
+                    use ::pine_interpreter::{Value, RuntimeError, EvaluatedArg};
+
+                    #body
+
+                    let instance = Self {
+                        #struct_construction
+                    };
+
+                    instance.execute(ctx)
+                }
+
+                pub fn name() -> &'static str {
+                    #function_name
+                }
             }
         }
     };
@@ -125,10 +222,11 @@ pub fn builtin_function_derive(input: TokenStream) -> TokenStream {
 /// (`LogOutput`, `PlotOutput`, `LabelOutput`, `BoxOutput`). It only applies to
 /// structs that declare no generics of their own — one that holds a `Value<O>`
 /// states its bounds on `O` directly.
-fn parse_builtin_attributes(input: &DeriveInput) -> (String, usize, Option<syn::Ident>) {
+fn parse_builtin_attributes(input: &DeriveInput) -> (String, usize, Option<syn::Ident>, bool) {
     let mut function_name = None;
     let mut type_params_count = 0;
     let mut output_bound = None;
+    let mut stateful = false;
 
     for attr in &input.attrs {
         if let Meta::List(meta_list) = &attr.meta {
@@ -171,13 +269,16 @@ fn parse_builtin_attributes(input: &DeriveInput) -> (String, usize, Option<syn::
                         }
                     }
                 }
+
+                // `stateful` opts the builtin into per-call-site memory.
+                stateful |= tokens_str.contains("stateful");
             }
         }
     }
 
     let function_name =
         function_name.expect("BuiltinFunction requires a #[builtin(name = \"...\")] attribute");
-    (function_name, type_params_count, output_bound)
+    (function_name, type_params_count, output_bound, stateful)
 }
 
 fn generate_type_param_extraction(
@@ -229,6 +330,18 @@ fn is_field_type_param(field: &Field) -> bool {
     })
 }
 
+/// `#[state]` marks a field that is not a Pine argument but the builtin's own
+/// memory, carried across bars by the call site rather than parsed from a call.
+fn is_field_state(field: &Field) -> bool {
+    field.attrs.iter().any(|attr| {
+        if let Meta::Path(path) = &attr.meta {
+            path.is_ident("state")
+        } else {
+            false
+        }
+    })
+}
+
 fn generate_field_parsing(
     fields: &syn::punctuated::Punctuated<Field, syn::token::Comma>,
 ) -> proc_macro2::TokenStream {
@@ -248,6 +361,11 @@ fn generate_field_parsing(
 
         // Skip type parameter fields - they're extracted separately
         if is_field_type_param(field) {
+            continue;
+        }
+
+        // Skip state fields - they come from the call site, not the arguments
+        if is_field_state(field) {
             continue;
         }
 
@@ -507,6 +625,11 @@ fn generate_field_validation(
             continue;
         }
 
+        // Skip state fields - they are never supplied by the caller
+        if is_field_state(field) {
+            continue;
+        }
+
         // Skip variadic fields - they don't need validation
         if is_field_variadic(field) {
             continue;
@@ -542,7 +665,13 @@ fn generate_struct_construction(
         .iter()
         .map(|field| {
             let field_name = field.ident.as_ref().unwrap();
-            quote! { #field_name }
+            // State fields start empty; the call site's saved values are restored
+            // over them right after construction.
+            if is_field_state(field) {
+                quote! { #field_name: Default::default() }
+            } else {
+                quote! { #field_name }
+            }
         })
         .collect();
 

--- a/crates/pine-builtins/src/ta/comparison.rs
+++ b/crates/pine-builtins/src/ta/comparison.rs
@@ -1,321 +1,327 @@
+use super::moving_averages::checked_length;
 use pine_builtin_macro::BuiltinFunction;
-use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use pine_interpreter::{Interpreter, PineOutput, RuntimeError, SeriesBuffer, Value};
 
 /// ta.change(source, length) - Difference between current and N bars ago
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.change")]
-pub struct TaChange<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.change", stateful)]
+pub struct TaChange {
+    source: f64,
     #[arg(default = 1.0)]
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaChange<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaChange {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
-
-        if let Value::Series(series) = &self.source {
-            let current = if let Value::Number(n) = *series.current {
-                n
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "Series must contain numbers".to_string(),
-                ));
-            };
-
-            if length == 0 {
-                return Ok(Value::Number(0.0));
-            }
-
-            // Get value N bars ago
-            if let Some(provider) = &ctx.historical_provider {
-                if let Some(Value::Number(prev)) = provider.get_historical(&series.id, length) {
-                    return Ok(Value::Number(current - prev));
-                }
-            }
-
-            // Not enough data
-            Ok(Value::Na)
-        } else if let Value::Number(_) = self.source {
-            // Single number has no change
-            Ok(Value::Number(0.0))
-        } else {
-            Err(RuntimeError::TypeError(
-                "source must be a number or series".to_string(),
-            ))
+        if length == 0 {
+            return Ok(Value::Number(0.0));
         }
+
+        // Reaching `length` bars back needs `length + 1` values in hand.
+        let Some(values) = self.window.observe(self.source, length + 1) else {
+            return Ok(Value::Na);
+        };
+
+        Ok(Value::Number(values[0] - values[length]))
     }
 }
 
 /// ta.highest(source, length) - Highest value over N bars
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.highest")]
-pub struct TaHighest<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.highest", stateful)]
+pub struct TaHighest {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaHighest<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaHighest {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-        Ok(Value::Number(max))
+        Ok(Value::Number(
+            values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        ))
     }
 }
 
 /// ta.lowest(source, length) - Lowest value over N bars
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.lowest")]
-pub struct TaLowest<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.lowest", stateful)]
+pub struct TaLowest {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaLowest<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaLowest {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
-        Ok(Value::Number(min))
+        Ok(Value::Number(
+            values.iter().copied().fold(f64::INFINITY, f64::min),
+        ))
     }
 }
 
-/// ta.cross(source1, source2) - True if two series crossed
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.cross")]
-pub struct TaCross<O: PineOutput> {
-    source1: Value<O>,
-    source2: Value<O>,
-}
-
-impl<O: PineOutput> TaCross<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let vals1 = ctx.get_series_values(&self.source1, 2)?;
-        let vals2 = ctx.get_series_values(&self.source2, 2)?;
-
-        if vals1.len() < 2 || vals2.len() < 2 {
-            return Ok(Value::Bool(false));
+/// The offset of the extreme value in `values` (newest first), as the negative
+/// bar count Pine reports: 0 is the current bar, -1 the one before it.
+fn extreme_offset(values: &[f64], better: fn(f64, f64) -> bool) -> f64 {
+    let mut best = 0;
+    for (i, &value) in values.iter().enumerate() {
+        if better(value, values[best]) {
+            best = i;
         }
-
-        // Cross happens when (prev1 < prev2 && curr1 > curr2) || (prev1 > prev2 && curr1 < curr2)
-        let crossed = (vals1[1] < vals2[1] && vals1[0] > vals2[0])
-            || (vals1[1] > vals2[1] && vals1[0] < vals2[0]);
-
-        Ok(Value::Bool(crossed))
     }
-}
-
-/// ta.crossover(source1, source2) - True if source1 crossed over source2
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.crossover")]
-pub struct TaCrossover<O: PineOutput> {
-    source1: Value<O>,
-    source2: Value<O>,
-}
-
-impl<O: PineOutput> TaCrossover<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let vals1 = ctx.get_series_values(&self.source1, 2)?;
-        let vals2 = ctx.get_series_values(&self.source2, 2)?;
-
-        if vals1.len() < 2 || vals2.len() < 2 {
-            return Ok(Value::Bool(false));
-        }
-
-        // Crossover: prev1 <= prev2 && curr1 > curr2
-        let crossed_over = vals1[1] <= vals2[1] && vals1[0] > vals2[0];
-
-        Ok(Value::Bool(crossed_over))
-    }
-}
-
-/// ta.crossunder(source1, source2) - True if source1 crossed under source2
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.crossunder")]
-pub struct TaCrossunder<O: PineOutput> {
-    source1: Value<O>,
-    source2: Value<O>,
-}
-
-impl<O: PineOutput> TaCrossunder<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let vals1 = ctx.get_series_values(&self.source1, 2)?;
-        let vals2 = ctx.get_series_values(&self.source2, 2)?;
-
-        if vals1.len() < 2 || vals2.len() < 2 {
-            return Ok(Value::Bool(false));
-        }
-
-        // Crossunder: prev1 >= prev2 && curr1 < curr2
-        let crossed_under = vals1[1] >= vals2[1] && vals1[0] < vals2[0];
-
-        Ok(Value::Bool(crossed_under))
-    }
-}
-
-/// ta.rising(source, length) - Test if source is rising for length bars
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.rising")]
-pub struct TaRising<O: PineOutput> {
-    source: Value<O>,
-    length: f64,
-}
-
-impl<O: PineOutput> TaRising<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Ok(Value::Bool(false));
-        }
-
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() <= length {
-            return Ok(Value::Bool(false));
-        }
-
-        // Check if current value is greater than all previous values
-        let current = values[0];
-        for value in values.iter().take(length + 1).skip(1) {
-            if current <= *value {
-                return Ok(Value::Bool(false));
-            }
-        }
-
-        Ok(Value::Bool(true))
-    }
-}
-
-/// ta.falling(source, length) - Test if source is falling for length bars
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.falling")]
-pub struct TaFalling<O: PineOutput> {
-    source: Value<O>,
-    length: f64,
-}
-
-impl<O: PineOutput> TaFalling<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Ok(Value::Bool(false));
-        }
-
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() <= length {
-            return Ok(Value::Bool(false));
-        }
-
-        // Check if current value is less than all previous values
-        let current = values[0];
-        for value in values.iter().take(length + 1).skip(1) {
-            if current >= *value {
-                return Ok(Value::Bool(false));
-            }
-        }
-
-        Ok(Value::Bool(true))
+    // Negating 0 would give `-0`, which prints as "-0" rather than "0".
+    if best == 0 {
+        0.0
+    } else {
+        -(best as f64)
     }
 }
 
 /// ta.highestbars(source, length) - Offset to highest value (0 = current bar)
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.highestbars")]
-pub struct TaHighestbars<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.highestbars", stateful)]
+pub struct TaHighestbars {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaHighestbars<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaHighestbars {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // Find index of maximum value
-        let mut max_idx = 0;
-        let mut max_val = values[0];
-
-        for (i, &val) in values.iter().enumerate() {
-            if val > max_val {
-                max_val = val;
-                max_idx = i;
-            }
-        }
-
-        // Return negative offset (0 = current, -1 = 1 bar ago, etc.)
-        Ok(Value::Number(-(max_idx as f64)))
+        Ok(Value::Number(extreme_offset(&values, |a, b| a > b)))
     }
 }
 
 /// ta.lowestbars(source, length) - Offset to lowest value (0 = current bar)
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.lowestbars")]
-pub struct TaLowestbars<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.lowestbars", stateful)]
+pub struct TaLowestbars {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaLowestbars<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaLowestbars {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
+
+        let Some(values) = self.window.observe(self.source, length) else {
+            return Ok(Value::Na);
+        };
+
+        Ok(Value::Number(extreme_offset(&values, |a, b| a < b)))
+    }
+}
+
+/// ta.rising(source, length) - Test if source rose on each of the last N bars
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.rising", stateful)]
+pub struct TaRising {
+    source: f64,
+    length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
+}
+
+impl TaRising {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
+            return Ok(Value::Bool(false));
         }
 
-        let values = ctx.get_series_values(&self.source, length)?;
+        let Some(values) = self.window.observe(self.source, length + 1) else {
+            return Ok(Value::Bool(false));
+        };
 
-        if values.is_empty() {
-            return Ok(Value::Na);
+        Ok(Value::Bool(values.windows(2).all(|pair| pair[0] > pair[1])))
+    }
+}
+
+/// ta.falling(source, length) - Test if source fell on each of the last N bars
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.falling", stateful)]
+pub struct TaFalling {
+    source: f64,
+    length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
+}
+
+impl TaFalling {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = self.length as usize;
+        if length == 0 {
+            return Ok(Value::Bool(false));
         }
 
-        // Find index of minimum value
-        let mut min_idx = 0;
-        let mut min_val = values[0];
+        let Some(values) = self.window.observe(self.source, length + 1) else {
+            return Ok(Value::Bool(false));
+        };
 
-        for (i, &val) in values.iter().enumerate() {
-            if val < min_val {
-                min_val = val;
-                min_idx = i;
-            }
-        }
+        Ok(Value::Bool(values.windows(2).all(|pair| pair[0] < pair[1])))
+    }
+}
 
-        // Return negative offset (0 = current, -1 = 1 bar ago, etc.)
-        Ok(Value::Number(-(min_idx as f64)))
+/// How two series sat relative to each other on this bar and the last, which is
+/// all the cross tests need.
+struct Crossing {
+    now_above: bool,
+    was_above: bool,
+}
+
+impl Crossing {
+    /// `None` until both series have two bars of history.
+    fn observe(
+        first: &mut SeriesBuffer<f64>,
+        second: &mut SeriesBuffer<f64>,
+        source1: f64,
+        source2: f64,
+    ) -> Option<Self> {
+        // Both sides advance together, so they fill on the same bar.
+        let firsts = first.observe(source1, 2);
+        let seconds = second.observe(source2, 2);
+        let (firsts, seconds) = (firsts?, seconds?);
+
+        Some(Self {
+            now_above: firsts[0] > seconds[0],
+            was_above: firsts[1] > seconds[1],
+        })
+    }
+}
+
+/// ta.cross(source1, source2) - Test if two series crossed in either direction
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.cross", stateful)]
+pub struct TaCross {
+    source1: f64,
+    source2: f64,
+    #[state]
+    first: SeriesBuffer<f64>,
+    #[state]
+    second: SeriesBuffer<f64>,
+}
+
+impl TaCross {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let Some(crossing) = Crossing::observe(
+            &mut self.first,
+            &mut self.second,
+            self.source1,
+            self.source2,
+        ) else {
+            return Ok(Value::Bool(false));
+        };
+
+        Ok(Value::Bool(crossing.now_above != crossing.was_above))
+    }
+}
+
+/// ta.crossover(source1, source2) - Test if source1 crossed above source2
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.crossover", stateful)]
+pub struct TaCrossover {
+    source1: f64,
+    source2: f64,
+    #[state]
+    first: SeriesBuffer<f64>,
+    #[state]
+    second: SeriesBuffer<f64>,
+}
+
+impl TaCrossover {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let Some(crossing) = Crossing::observe(
+            &mut self.first,
+            &mut self.second,
+            self.source1,
+            self.source2,
+        ) else {
+            return Ok(Value::Bool(false));
+        };
+
+        Ok(Value::Bool(crossing.now_above && !crossing.was_above))
+    }
+}
+
+/// ta.crossunder(source1, source2) - Test if source1 crossed below source2
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.crossunder", stateful)]
+pub struct TaCrossunder {
+    source1: f64,
+    source2: f64,
+    #[state]
+    first: SeriesBuffer<f64>,
+    #[state]
+    second: SeriesBuffer<f64>,
+}
+
+impl TaCrossunder {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let Some(crossing) = Crossing::observe(
+            &mut self.first,
+            &mut self.second,
+            self.source1,
+            self.source2,
+        ) else {
+            return Ok(Value::Bool(false));
+        };
+
+        Ok(Value::Bool(!crossing.now_above && crossing.was_above))
     }
 }

--- a/crates/pine-builtins/src/ta/mod.rs
+++ b/crates/pine-builtins/src/ta/mod.rs
@@ -23,147 +23,148 @@ pub fn register<O: PineOutput>(version: PineVersion) -> HashMap<String, Value<O>
     // Moving averages
     ta_ns.insert(
         "sma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaSma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaSma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "ema".to_string(),
-        Value::BuiltinFunction(Rc::new(TaEma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaEma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "rma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaRma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaRma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "wma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaWma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaWma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "vwma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaVwma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaVwma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "hma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaHma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaHma::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "swma".to_string(),
-        Value::BuiltinFunction(Rc::new(TaSwma::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaSwma::builtin_fn::<O>()),
     );
 
     // Statistics
     ta_ns.insert(
         "stdev".to_string(),
-        Value::BuiltinFunction(Rc::new(TaStdev::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaStdev::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "variance".to_string(),
-        Value::BuiltinFunction(Rc::new(TaVariance::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaVariance::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "median".to_string(),
-        Value::BuiltinFunction(Rc::new(TaMedian::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaMedian::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "dev".to_string(),
-        Value::BuiltinFunction(Rc::new(TaDev::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaDev::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "percentile_nearest_rank".to_string(),
-        Value::BuiltinFunction(Rc::new(TaPercentileNearestRank::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaPercentileNearestRank::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "cum".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCum::<O>::builtin_fn)),
+        // Stateful: the closure owns this script's per-call-site running totals.
+        Value::BuiltinFunction(TaCum::builtin_fn::<O>()),
     );
 
     // Volatility
     ta_ns.insert(
         "tr".to_string(),
-        Value::BuiltinFunction(Rc::new(TaTr::builtin_fn::<O>)),
+        Value::BuiltinFunction(TaTr::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "atr".to_string(),
-        Value::BuiltinFunction(Rc::new(TaAtr::builtin_fn::<O>)),
+        Value::BuiltinFunction(TaAtr::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "bb".to_string(),
-        Value::BuiltinFunction(Rc::new(TaBb::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaBb::builtin_fn::<O>()),
     );
 
     // Comparison & Signals
     ta_ns.insert(
         "change".to_string(),
-        Value::BuiltinFunction(Rc::new(TaChange::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaChange::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "highest".to_string(),
-        Value::BuiltinFunction(Rc::new(TaHighest::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaHighest::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "lowest".to_string(),
-        Value::BuiltinFunction(Rc::new(TaLowest::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaLowest::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "highestbars".to_string(),
-        Value::BuiltinFunction(Rc::new(TaHighestbars::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaHighestbars::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "lowestbars".to_string(),
-        Value::BuiltinFunction(Rc::new(TaLowestbars::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaLowestbars::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "rising".to_string(),
-        Value::BuiltinFunction(Rc::new(TaRising::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaRising::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "falling".to_string(),
-        Value::BuiltinFunction(Rc::new(TaFalling::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaFalling::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "cross".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCross::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaCross::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "crossover".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCrossover::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaCrossover::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "crossunder".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCrossunder::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaCrossunder::builtin_fn::<O>()),
     );
 
     // Oscillators & Indicators
     ta_ns.insert(
         "rsi".to_string(),
-        Value::BuiltinFunction(Rc::new(TaRsi::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaRsi::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "cci".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCci::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaCci::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "mom".to_string(),
-        Value::BuiltinFunction(Rc::new(TaMom::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaMom::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "roc".to_string(),
-        Value::BuiltinFunction(Rc::new(TaRoc::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaRoc::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "cmo".to_string(),
-        Value::BuiltinFunction(Rc::new(TaCmo::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaCmo::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "linreg".to_string(),
-        Value::BuiltinFunction(Rc::new(TaLinreg::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaLinreg::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "stoch".to_string(),
-        Value::BuiltinFunction(Rc::new(TaStoch::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaStoch::builtin_fn::<O>()),
     );
     ta_ns.insert(
         "mfi".to_string(),
-        Value::BuiltinFunction(Rc::new(TaMfi::<O>::builtin_fn)),
+        Value::BuiltinFunction(TaMfi::builtin_fn::<O>()),
     );
 
     if matches!(version, PineVersion::V5 | PineVersion::V6) {

--- a/crates/pine-builtins/src/ta/moving_averages.rs
+++ b/crates/pine-builtins/src/ta/moving_averages.rs
@@ -1,397 +1,266 @@
 use pine_builtin_macro::BuiltinFunction;
-use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use pine_interpreter::{Interpreter, PineOutput, RuntimeError, SeriesBuffer, Value};
+
+/// One step of an exponentially smoothed average: `alpha * source + (1 - alpha)
+/// * previous`. Pine seeds the recursion with the simple average of the first
+/// `length` values, which is what `seed` carries on the very first step.
+pub(crate) fn smooth_step(previous: Option<f64>, source: f64, alpha: f64, seed: &[f64]) -> f64 {
+    match previous {
+        Some(previous) => alpha * source + (1.0 - alpha) * previous,
+        None => seed.iter().sum::<f64>() / seed.len() as f64,
+    }
+}
+
+/// Weighted average of `values` (newest first), weighting the newest highest:
+/// `n, n-1, … 1`.
+pub(crate) fn weighted_average(values: &[f64]) -> f64 {
+    let len = values.len();
+    let weighted: f64 = values
+        .iter()
+        .enumerate()
+        .map(|(i, &value)| value * (len - i) as f64)
+        .sum();
+    let total_weight = (len * (len + 1)) as f64 / 2.0;
+    weighted / total_weight
+}
+
+/// Rejects a zero length, which every windowed average requires.
+pub(crate) fn checked_length(length: f64) -> Result<usize, RuntimeError> {
+    let length = length as usize;
+    if length == 0 {
+        return Err(RuntimeError::TypeError(
+            "length must be greater than 0".to_string(),
+        ));
+    }
+    Ok(length)
+}
 
 /// ta.sma(source, length) - Simple Moving Average
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.sma")]
-pub struct TaSma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.sma", stateful)]
+pub struct TaSma {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaSma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaSma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let sum: f64 = values.iter().sum();
-        let avg = sum / values.len() as f64;
-        Ok(Value::Number(avg))
+        Ok(Value::Number(values.iter().sum::<f64>() / length as f64))
     }
 }
 
 /// ta.ema(source, length) - Exponential Moving Average
+///
+/// `alpha * source + (1 - alpha) * ema[1]` with `alpha = 2 / (length + 1)`,
+/// carried across bars. Like Pine, it is na until `length` bars have been seen
+/// and then starts from their simple average.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.ema")]
-pub struct TaEma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.ema", stateful)]
+pub struct TaEma {
+    source: f64,
     length: f64,
+    /// Holds the first `length` values, which seed the recursion.
+    #[state]
+    window: SeriesBuffer<f64>,
+    #[state]
+    previous: Option<f64>,
 }
 
-impl<O: PineOutput> TaEma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaEma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // EMA calculation: EMA = (Close - EMA(prev)) * multiplier + EMA(prev)
-        // where multiplier = 2 / (length + 1)
-        let multiplier = 2.0 / (length as f64 + 1.0);
+        let Some(seed) = self.window.observe(self.source, length) else {
+            return Ok(Value::Na);
+        };
 
-        if let Value::Series(series) = &self.source {
-            let mut values = Vec::new();
+        let alpha = 2.0 / (length as f64 + 1.0);
+        let ema = smooth_step(self.previous, self.source, alpha, &seed);
+        self.previous = Some(ema);
 
-            // Get current value
-            if let Value::Number(n) = *series.current {
-                values.push(n);
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "Series must contain numbers".to_string(),
-                ));
-            }
-
-            // Get historical values
-            if let Some(provider) = &ctx.historical_provider {
-                for i in 1..length * 2 {
-                    // Get more data for better EMA accuracy
-                    if let Some(Value::Number(n)) = provider.get_historical(&series.id, i) {
-                        values.push(n);
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            if values.is_empty() {
-                return Ok(Value::Na);
-            }
-
-            // Start with SMA for first value
-            let initial_sma: f64 = values.iter().take(length.min(values.len())).sum::<f64>()
-                / length.min(values.len()) as f64;
-
-            // Calculate EMA backwards from oldest to newest
-            let mut ema = initial_sma;
-            for &val in values
-                .iter()
-                .rev()
-                .skip(length.min(values.len()))
-                .take(values.len() - length.min(values.len()))
-            {
-                ema = (val - ema) * multiplier + ema;
-            }
-
-            // Apply final value (current)
-            ema = (values[0] - ema) * multiplier + ema;
-
-            Ok(Value::Number(ema))
-        } else if let Value::Number(n) = self.source {
-            Ok(Value::Number(n))
-        } else {
-            Err(RuntimeError::TypeError(
-                "source must be a number or series".to_string(),
-            ))
-        }
+        Ok(Value::Number(ema))
     }
 }
 
 /// ta.rma(source, length) - Rolling Moving Average (Wilder's Smoothing)
+///
+/// The same recursion as [`TaEma`] with `alpha = 1 / length`, which smooths more
+/// slowly. This is what `ta.rsi` averages its gains and losses with.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.rma")]
-pub struct TaRma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.rma", stateful)]
+pub struct TaRma {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
+    #[state]
+    previous: Option<f64>,
 }
 
-impl<O: PineOutput> TaRma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaRma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // RMA calculation: RMA = (prev_RMA * (length - 1) + current) / length
-        // This is equivalent to EMA with alpha = 1/length
+        let Some(seed) = self.window.observe(self.source, length) else {
+            return Ok(Value::Na);
+        };
 
-        if let Value::Series(series) = &self.source {
-            let mut values = Vec::new();
+        let rma = smooth_step(self.previous, self.source, 1.0 / length as f64, &seed);
+        self.previous = Some(rma);
 
-            // Get current value
-            if let Value::Number(n) = *series.current {
-                values.push(n);
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "Series must contain numbers".to_string(),
-                ));
-            }
-
-            // Get historical values
-            if let Some(provider) = &ctx.historical_provider {
-                for i in 1..length * 2 {
-                    if let Some(Value::Number(n)) = provider.get_historical(&series.id, i) {
-                        values.push(n);
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            if values.is_empty() {
-                return Ok(Value::Na);
-            }
-
-            // Start with SMA
-            let initial_sma: f64 = values.iter().take(length.min(values.len())).sum::<f64>()
-                / length.min(values.len()) as f64;
-
-            // Calculate RMA
-            let mut rma = initial_sma;
-            let alpha = 1.0 / length as f64;
-
-            for &val in values
-                .iter()
-                .rev()
-                .skip(length.min(values.len()))
-                .take(values.len() - length.min(values.len()))
-            {
-                rma = alpha * val + (1.0 - alpha) * rma;
-            }
-
-            // Apply current value
-            rma = alpha * values[0] + (1.0 - alpha) * rma;
-
-            Ok(Value::Number(rma))
-        } else if let Value::Number(n) = self.source {
-            Ok(Value::Number(n))
-        } else {
-            Err(RuntimeError::TypeError(
-                "source must be a number or series".to_string(),
-            ))
-        }
+        Ok(Value::Number(rma))
     }
 }
 
 /// ta.wma(source, length) - Weighted Moving Average
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.wma")]
-pub struct TaWma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.wma", stateful)]
+pub struct TaWma {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaWma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaWma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // WMA calculation: sum(price[i] * (length - i)) / sum(length - i)
-        // Most recent data has highest weight
+        let Some(values) = self.window.observe(self.source, length) else {
+            return Ok(Value::Na);
+        };
 
-        if let Value::Series(series) = &self.source {
-            let mut values = Vec::new();
-
-            // Get current value
-            if let Value::Number(n) = *series.current {
-                values.push(n);
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "Series must contain numbers".to_string(),
-                ));
-            }
-
-            // Get historical values
-            if let Some(provider) = &ctx.historical_provider {
-                for i in 1..length {
-                    if let Some(Value::Number(n)) = provider.get_historical(&series.id, i) {
-                        values.push(n);
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            if values.is_empty() {
-                return Ok(Value::Na);
-            }
-
-            let actual_length = values.len();
-            let mut weighted_sum = 0.0;
-            let mut weight_sum = 0.0;
-
-            for (i, &val) in values.iter().enumerate() {
-                let weight = (actual_length - i) as f64;
-                weighted_sum += val * weight;
-                weight_sum += weight;
-            }
-
-            Ok(Value::Number(weighted_sum / weight_sum))
-        } else if let Value::Number(n) = self.source {
-            Ok(Value::Number(n))
-        } else {
-            Err(RuntimeError::TypeError(
-                "source must be a number or series".to_string(),
-            ))
-        }
+        Ok(Value::Number(weighted_average(&values)))
     }
 }
 
 /// ta.vwma(source, length) - Volume Weighted Moving Average
-/// Note: Requires volume series to be available in context
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.vwma")]
-pub struct TaVwma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.vwma", stateful)]
+pub struct TaVwma {
+    source: f64,
     length: f64,
+    #[state]
+    prices: SeriesBuffer<f64>,
+    #[state]
+    volumes: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaVwma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaVwma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // Get price values
-        let price_values = ctx.get_series_values(&self.source, length)?;
-
-        if price_values.is_empty() {
-            return Ok(Value::Na);
-        }
-
-        // Get volume series from context
         let volume = ctx
             .get_variable("volume")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("volume".to_string()))?;
+            .ok_or_else(|| RuntimeError::UndefinedVariable("volume".to_string()))?
+            .as_number()?;
 
-        let volume_values = ctx.get_series_values(volume, length)?;
-
-        if volume_values.len() != price_values.len() {
+        // Both sides advance together, so they fill on the same bar.
+        let prices = self.prices.observe(self.source, length);
+        let volumes = self.volumes.observe(volume, length);
+        let (Some(prices), Some(volumes)) = (prices, volumes) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // VWMA = sum(price * volume) / sum(volume)
-        let mut weighted_sum = 0.0;
-        let mut volume_sum = 0.0;
-
-        for i in 0..price_values.len() {
-            weighted_sum += price_values[i] * volume_values[i];
-            volume_sum += volume_values[i];
-        }
-
+        let volume_sum: f64 = volumes.iter().sum();
         if volume_sum == 0.0 {
             return Ok(Value::Na);
         }
 
-        Ok(Value::Number(weighted_sum / volume_sum))
+        let weighted: f64 = prices
+            .iter()
+            .zip(&volumes)
+            .map(|(price, volume)| price * volume)
+            .sum();
+
+        Ok(Value::Number(weighted / volume_sum))
     }
 }
 
 /// ta.hma(source, length) - Hull Moving Average
+///
+/// `wma(2 * wma(source, length/2) - wma(source, length), sqrt(length))`. The
+/// outer average needs the inner one's own history, so it keeps a second buffer.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.hma")]
-pub struct TaHma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.hma", stateful)]
+pub struct TaHma {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
+    /// Past values of `2 * wma(length/2) - wma(length)`, which the outer
+    /// weighted average smooths.
+    #[state]
+    raw: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaHma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaHma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
+        let half = (length / 2).max(1);
+        let root = ((length as f64).sqrt().floor() as usize).max(1);
 
-        // HMA = WMA(2 * WMA(n/2) - WMA(n), sqrt(n))
-        // Simplified implementation: just use WMA of source
-        let half_length = (length as f64 / 2.0).floor() as usize;
-        let sqrt_length = (length as f64).sqrt().floor() as usize;
-
-        // Get values for calculations
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() || values.len() < sqrt_length {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // Calculate WMA(n/2)
-        let wma_half = Self::calc_wma(&values[..half_length.min(values.len())]);
+        let raw = 2.0 * weighted_average(&values[..half]) - weighted_average(&values);
 
-        // Calculate WMA(n)
-        let wma_full = Self::calc_wma(&values);
+        let Some(smoothed) = self.raw.observe(raw, root) else {
+            return Ok(Value::Na);
+        };
 
-        // 2 * WMA(n/2) - WMA(n)
-        let raw_hma = 2.0 * wma_half - wma_full;
-
-        // For simplicity, return the raw value instead of recalculating WMA
-        // Full implementation would need state across bars
-        Ok(Value::Number(raw_hma))
-    }
-
-    fn calc_wma(values: &[f64]) -> f64 {
-        if values.is_empty() {
-            return 0.0;
-        }
-
-        let len = values.len();
-        let mut weighted_sum = 0.0;
-        let mut weight_sum = 0.0;
-
-        for (i, &val) in values.iter().enumerate() {
-            let weight = (len - i) as f64;
-            weighted_sum += val * weight;
-            weight_sum += weight;
-        }
-
-        if weight_sum == 0.0 {
-            0.0
-        } else {
-            weighted_sum / weight_sum
-        }
+        Ok(Value::Number(weighted_average(&smoothed)))
     }
 }
 
-/// ta.swma(source) - Symmetrically Weighted Moving Average (4-bar)
+/// ta.swma(source) - Symmetrically Weighted Moving Average
+///
+/// A fixed 4-bar average weighted `1, 2, 2, 1` from newest to oldest.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.swma")]
-pub struct TaSwma<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.swma", stateful)]
+pub struct TaSwma {
+    source: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaSwma<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        // SWMA uses fixed 4-bar window with weights [1, 2, 2, 1]
-        let values = ctx.get_series_values(&self.source, 4)?;
-
-        if values.len() < 4 {
+impl TaSwma {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let Some(values) = self.window.observe(self.source, 4) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // Weights: 1, 2, 2, 1 (symmetrical)
-        let swma = (values[0] * 1.0 + values[1] * 2.0 + values[2] * 2.0 + values[3] * 1.0) / 6.0;
-
+        let swma = (values[0] + 2.0 * values[1] + 2.0 * values[2] + values[3]) / 6.0;
         Ok(Value::Number(swma))
     }
 }

--- a/crates/pine-builtins/src/ta/oscillators.rs
+++ b/crates/pine-builtins/src/ta/oscillators.rs
@@ -1,16 +1,37 @@
+use super::moving_averages::{checked_length, smooth_step};
 use pine_builtin_macro::BuiltinFunction;
-use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use pine_interpreter::{Interpreter, PineOutput, RuntimeError, SeriesBuffer, Value};
 
 /// ta.rsi(source, length) - Relative Strength Index
+///
+/// `100 - 100 / (1 + rs)`, where `rs` is Wilder-smoothed gains over Wilder-
+/// smoothed losses. Both averages are carried across bars by the call site, so
+/// this is the real recursive definition rather than an average of the last
+/// `length` changes.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.rsi")]
-pub struct TaRsi<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.rsi", stateful)]
+pub struct TaRsi {
+    source: f64,
     length: f64,
+    /// Last bar's source, to difference against. `None` on the first bar, when
+    /// there is no change to measure yet.
+    #[state]
+    previous: Option<f64>,
+    #[state]
+    gains: SeriesBuffer<f64>,
+    #[state]
+    losses: SeriesBuffer<f64>,
+    #[state]
+    avg_gain: Option<f64>,
+    #[state]
+    avg_loss: Option<f64>,
 }
 
-impl<O: PineOutput> TaRsi<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaRsi {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -18,217 +39,197 @@ impl<O: PineOutput> TaRsi<O> {
             ));
         }
 
-        // Get enough values to calculate changes
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() < 2 {
+        let Some(previous) = self.previous.replace(self.source) else {
+            // First bar: no previous value, so no change to measure yet.
             return Ok(Value::Na);
-        }
+        };
 
-        // Calculate gains and losses
-        let mut gains = Vec::new();
-        let mut losses = Vec::new();
+        let change = self.source - previous;
+        let gain = change.max(0.0);
+        let loss = (-change).max(0.0);
 
-        for i in 0..values.len() - 1 {
-            let change = values[i] - values[i + 1];
-            if change > 0.0 {
-                gains.push(change);
-                losses.push(0.0);
-            } else {
-                gains.push(0.0);
-                losses.push(-change);
-            }
-        }
-
-        if gains.is_empty() {
+        // Both sides advance together, so they fill on the same bar.
+        let gain_seed = self.gains.observe(gain, length);
+        let loss_seed = self.losses.observe(loss, length);
+        let (Some(gain_seed), Some(loss_seed)) = (gain_seed, loss_seed) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // Calculate RMA of gains and losses
-        let avg_gain: f64 = gains.iter().take(length.min(gains.len())).sum::<f64>()
-            / length.min(gains.len()) as f64;
-        let avg_loss: f64 = losses.iter().take(length.min(losses.len())).sum::<f64>()
-            / length.min(losses.len()) as f64;
+        let alpha = 1.0 / length as f64;
+        let avg_gain = smooth_step(self.avg_gain, gain, alpha, &gain_seed);
+        let avg_loss = smooth_step(self.avg_loss, loss, alpha, &loss_seed);
+        self.avg_gain = Some(avg_gain);
+        self.avg_loss = Some(avg_loss);
 
+        // Only-gains saturates at 100, only-losses at 0, and no movement at all
+        // sits in the middle.
         if avg_loss == 0.0 {
-            return Ok(Value::Number(100.0));
+            return Ok(Value::Number(if avg_gain == 0.0 { 50.0 } else { 100.0 }));
         }
 
         let rs = avg_gain / avg_loss;
-        let rsi = 100.0 - (100.0 / (1.0 + rs));
-
-        Ok(Value::Number(rsi))
+        Ok(Value::Number(100.0 - 100.0 / (1.0 + rs)))
     }
 }
 
 /// ta.cci(source, length) - Commodity Channel Index
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.cci")]
-pub struct TaCci<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.cci", stateful)]
+pub struct TaCci {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaCci<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaCci {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // CCI = (Typical Price - SMA) / (0.015 * Mean Deviation)
-        // For simplicity, we use source directly instead of typical price
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
-        // Calculate SMA
-        let sma: f64 = values.iter().sum::<f64>() / values.len() as f64;
-
-        // Calculate mean absolute deviation
-        let mad: f64 = values.iter().map(|&v| (v - sma).abs()).sum::<f64>() / values.len() as f64;
+        let sma: f64 = values.iter().sum::<f64>() / length as f64;
+        let mad: f64 = values.iter().map(|&v| (v - sma).abs()).sum::<f64>() / length as f64;
 
         if mad == 0.0 {
             return Ok(Value::Na);
         }
 
-        let cci = (values[0] - sma) / (0.015 * mad);
-        Ok(Value::Number(cci))
+        Ok(Value::Number((values[0] - sma) / (0.015 * mad)))
     }
 }
 
-/// ta.mom(source, length) - Momentum
+/// ta.mom(source, length) - Momentum: the change over `length` bars.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.mom")]
-pub struct TaMom<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.mom", stateful)]
+pub struct TaMom {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaMom<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaMom {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
 
-        // Momentum is just current - value N bars ago
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() <= length {
+        // `length` bars back needs `length + 1` values in hand.
+        let Some(values) = self.window.observe(self.source, length + 1) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let momentum = values[0] - values[length];
-        Ok(Value::Number(momentum))
+        Ok(Value::Number(values[0] - values[length]))
     }
 }
 
-/// ta.roc(source, length) - Rate of Change
+/// ta.roc(source, length) - Rate of Change, as a percentage.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.roc")]
-pub struct TaRoc<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.roc", stateful)]
+pub struct TaRoc {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaRoc<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaRoc {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
 
-        // ROC = ((current - previous) / previous) * 100
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() <= length {
+        let Some(values) = self.window.observe(self.source, length + 1) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let current = values[0];
         let previous = values[length];
-
         if previous == 0.0 {
             return Ok(Value::Na);
         }
 
-        let roc = ((current - previous) / previous) * 100.0;
-        Ok(Value::Number(roc))
+        Ok(Value::Number((values[0] - previous) / previous * 100.0))
     }
 }
 
 /// ta.cmo(source, length) - Chande Momentum Oscillator
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.cmo")]
-pub struct TaCmo<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.cmo", stateful)]
+pub struct TaCmo {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaCmo<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaCmo {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // CMO = 100 * (sum of gains - sum of losses) / (sum of gains + sum of losses)
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-
-        if values.len() < 2 {
+        // `length` changes need `length + 1` values in hand.
+        let Some(values) = self.window.observe(self.source, length + 1) else {
             return Ok(Value::Na);
-        }
+        };
 
-        let mut sum_gains = 0.0;
-        let mut sum_losses = 0.0;
-
-        for i in 0..values.len() - 1 {
-            let change = values[i] - values[i + 1];
+        let mut gains = 0.0;
+        let mut losses = 0.0;
+        for pair in values.windows(2) {
+            let change = pair[0] - pair[1];
             if change > 0.0 {
-                sum_gains += change;
+                gains += change;
             } else {
-                sum_losses += -change;
+                losses -= change;
             }
         }
 
-        let total = sum_gains + sum_losses;
+        let total = gains + losses;
         if total == 0.0 {
             return Ok(Value::Number(0.0));
         }
 
-        let cmo = 100.0 * (sum_gains - sum_losses) / total;
-        Ok(Value::Number(cmo))
+        Ok(Value::Number(100.0 * (gains - losses) / total))
     }
 }
 
 /// ta.stoch(source, high, low, length) - Stochastic: where `source` sits inside
 /// the `[lowest(low), highest(high)]` range of the last `length` bars, as 0..100.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.stoch")]
-pub struct TaStoch<O: PineOutput> {
-    source: Value<O>,
-    high: Value<O>,
-    low: Value<O>,
+#[builtin(name = "ta.stoch", stateful)]
+pub struct TaStoch {
+    source: f64,
+    high: f64,
+    low: f64,
     length: f64,
+    #[state]
+    highs: SeriesBuffer<f64>,
+    #[state]
+    lows: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaStoch<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaStoch {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let source = ctx.get_series_values(&self.source, 1)?;
-        let highs = ctx.get_series_values(&self.high, length)?;
-        let lows = ctx.get_series_values(&self.low, length)?;
-
-        if source.is_empty() || highs.is_empty() || lows.is_empty() {
+        // Both sides advance together, so they fill on the same bar.
+        let highs = self.highs.observe(self.high, length);
+        let lows = self.lows.observe(self.low, length);
+        let (Some(highs), Some(lows)) = (highs, lows) else {
             return Ok(Value::Na);
-        }
+        };
 
         let highest = highs.iter().copied().fold(f64::NEG_INFINITY, f64::max);
         let lowest = lows.iter().copied().fold(f64::INFINITY, f64::min);
@@ -238,7 +239,7 @@ impl<O: PineOutput> TaStoch<O> {
             return Ok(Value::Number(0.0));
         }
 
-        Ok(Value::Number(100.0 * (source[0] - lowest) / range))
+        Ok(Value::Number(100.0 * (self.source - lowest) / range))
     }
 }
 
@@ -246,93 +247,96 @@ impl<O: PineOutput> TaStoch<O> {
 /// bar's money flow counts as positive or negative according to the sign of the
 /// change in `source`.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.mfi")]
-pub struct TaMfi<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.mfi", stateful)]
+pub struct TaMfi {
+    source: f64,
     length: f64,
+    /// Money flow on up bars, 0 otherwise — Pine's `upper` sum.
+    #[state]
+    rising: SeriesBuffer<f64>,
+    /// Money flow on down bars, 0 otherwise — Pine's `lower` sum.
+    #[state]
+    falling: SeriesBuffer<f64>,
+    #[state]
+    previous: Option<f64>,
 }
 
-impl<O: PineOutput> TaMfi<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaMfi {
+    fn execute<O: PineOutput>(
+        &mut self,
+        ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
         let volume = ctx
             .get_variable("volume")
             .ok_or_else(|| RuntimeError::UndefinedVariable("volume".to_string()))?
-            .clone();
+            .as_number()?;
 
-        // One extra source value: each of the `length` bars needs its predecessor
-        // to know whether its money flow is positive or negative.
-        let values = ctx.get_series_values(&self.source, length + 1)?;
-        let volumes = ctx.get_series_values(&volume, length)?;
-
-        let bars = (values.len().saturating_sub(1)).min(volumes.len());
-        if bars == 0 {
+        let Some(previous) = self.previous.replace(self.source) else {
+            // First bar: no previous value, so the flow has no direction yet.
             return Ok(Value::Na);
-        }
+        };
 
-        let mut positive = 0.0;
-        let mut negative = 0.0;
-        for i in 0..bars {
-            let flow = values[i] * volumes[i];
-            if values[i] > values[i + 1] {
-                positive += flow;
-            } else if values[i] < values[i + 1] {
-                negative += flow;
-            }
-        }
+        // Each bar's flow lands wholly on one side; an unchanged bar on neither.
+        // The flow keeps the source's own sign, as Pine's does, so the two sides
+        // stay meaningful even for a source that goes negative.
+        let flow = self.source * volume;
+        let change = self.source - previous;
+        let rising = self
+            .rising
+            .observe(if change > 0.0 { flow } else { 0.0 }, length);
+        let falling = self
+            .falling
+            .observe(if change < 0.0 { flow } else { 0.0 }, length);
+        let (Some(rising), Some(falling)) = (rising, falling) else {
+            return Ok(Value::Na);
+        };
 
-        if negative == 0.0 {
+        let upper: f64 = rising.iter().sum();
+        let lower: f64 = falling.iter().sum();
+
+        // No down bars in the window means the index is pinned at its top.
+        if lower == 0.0 {
             return Ok(Value::Number(100.0));
         }
 
-        Ok(Value::Number(100.0 - 100.0 / (1.0 + positive / negative)))
+        Ok(Value::Number(100.0 - 100.0 / (1.0 + upper / lower)))
     }
 }
 
 /// ta.linreg(source, length, offset) - Linear Regression
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.linreg")]
-pub struct TaLinreg<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.linreg", stateful)]
+pub struct TaLinreg {
+    source: f64,
     length: f64,
     #[arg(default = 0.0)]
     offset: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaLinreg<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaLinreg {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         let n = values.len() as f64;
-
-        // Calculate means
         let mean_x = (values.len() - 1) as f64 / 2.0;
         let mean_y: f64 = values.iter().sum::<f64>() / n;
 
-        // Calculate slope (beta)
         let mut numerator = 0.0;
         let mut denominator = 0.0;
-
-        for (i, &val) in values.iter().enumerate() {
+        for (i, &value) in values.iter().enumerate() {
             let x_dev = i as f64 - mean_x;
-            numerator += x_dev * (val - mean_y);
+            numerator += x_dev * (value - mean_y);
             denominator += x_dev * x_dev;
         }
 
@@ -343,10 +347,6 @@ impl<O: PineOutput> TaLinreg<O> {
         let slope = numerator / denominator;
         let intercept = mean_y - slope * mean_x;
 
-        // Calculate value at offset (0 = current bar)
-        let x_pos = self.offset;
-        let linreg_val = intercept + slope * x_pos;
-
-        Ok(Value::Number(linreg_val))
+        Ok(Value::Number(intercept + slope * self.offset))
     }
 }

--- a/crates/pine-builtins/src/ta/statistics.rs
+++ b/crates/pine-builtins/src/ta/statistics.rs
@@ -1,16 +1,21 @@
 use pine_builtin_macro::BuiltinFunction;
-use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use pine_interpreter::{Interpreter, PineOutput, RuntimeError, SeriesBuffer, Value};
 
 /// ta.stdev(source, length) - Standard Deviation
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.stdev")]
-pub struct TaStdev<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.stdev", stateful)]
+pub struct TaStdev {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaStdev<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaStdev {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -18,11 +23,9 @@ impl<O: PineOutput> TaStdev<O> {
             ));
         }
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         if values.len() == 1 {
             return Ok(Value::Number(0.0));
@@ -48,14 +51,19 @@ impl<O: PineOutput> TaStdev<O> {
 
 /// ta.variance(source, length) - Variance
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.variance")]
-pub struct TaVariance<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.variance", stateful)]
+pub struct TaVariance {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaVariance<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaVariance {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -63,11 +71,9 @@ impl<O: PineOutput> TaVariance<O> {
             ));
         }
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         if values.len() == 1 {
             return Ok(Value::Number(0.0));
@@ -92,14 +98,19 @@ impl<O: PineOutput> TaVariance<O> {
 
 /// ta.median(source, length) - Median value
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.median")]
-pub struct TaMedian<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.median", stateful)]
+pub struct TaMedian {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaMedian<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaMedian {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -107,22 +118,20 @@ impl<O: PineOutput> TaMedian<O> {
             ));
         }
 
-        let mut values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(mut values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         // Sort to find median
         values.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        let median = if values.len() % 2 == 0 {
-            // Even number of elements - average of two middle values
-            let mid = values.len() / 2;
-            (values[mid - 1] + values[mid]) / 2.0
-        } else {
+        let mid = values.len() / 2;
+        let median = if values.len() % 2 == 1 {
             // Odd number of elements - middle value
-            values[values.len() / 2]
+            values[mid]
+        } else {
+            // Even number of elements - average of two middle values
+            (values[mid - 1] + values[mid]) / 2.0
         };
 
         Ok(Value::Number(median))
@@ -133,15 +142,20 @@ impl<O: PineOutput> TaMedian<O> {
 /// nearest-rank method: the smallest value at or below which `percentage` of the
 /// last `length` values fall.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.percentile_nearest_rank")]
-pub struct TaPercentileNearestRank<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.percentile_nearest_rank", stateful)]
+pub struct TaPercentileNearestRank {
+    source: f64,
     length: f64,
     percentage: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaPercentileNearestRank<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaPercentileNearestRank {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -149,11 +163,9 @@ impl<O: PineOutput> TaPercentileNearestRank<O> {
             ));
         }
 
-        let mut values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(mut values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
@@ -167,38 +179,44 @@ impl<O: PineOutput> TaPercentileNearestRank<O> {
 
 /// ta.cum(source) - Running total of `source` from the first bar onwards.
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.cum")]
-pub struct TaCum<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.cum", stateful)]
+pub struct TaCum {
+    source: f64,
+    /// The total so far, carried across bars by this call site.
+    #[state]
+    total: f64,
 }
 
-impl<O: PineOutput> TaCum<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        // `usize::MAX` means "the whole history": `get_series_values` stops as
-        // soon as the provider runs out of bars.
-        let values = ctx.get_series_values(&self.source, usize::MAX)?;
-
-        if values.is_empty() {
-            return Ok(Value::Na);
+impl TaCum {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        // Pine's `cum` skips na (which arrives as NaN) rather than letting it
+        // poison the total for good.
+        if self.source.is_finite() {
+            self.total += self.source;
         }
 
-        // Pine's `cum` skips na rather than poisoning the total.
-        Ok(Value::Number(
-            values.iter().filter(|v| v.is_finite()).sum::<f64>(),
-        ))
+        Ok(Value::Number(self.total))
     }
 }
 
 /// ta.dev(source, length) - Mean Absolute Deviation
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.dev")]
-pub struct TaDev<O: PineOutput> {
-    source: Value<O>,
+#[builtin(name = "ta.dev", stateful)]
+pub struct TaDev {
+    source: f64,
     length: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaDev<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
+impl TaDev {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
         let length = self.length as usize;
         if length == 0 {
             return Err(RuntimeError::TypeError(
@@ -206,11 +224,9 @@ impl<O: PineOutput> TaDev<O> {
             ));
         }
 
-        let values = ctx.get_series_values(&self.source, length)?;
-
-        if values.is_empty() {
+        let Some(values) = self.window.observe(self.source, length) else {
             return Ok(Value::Na);
-        }
+        };
 
         // Calculate mean
         let mean: f64 = values.iter().sum::<f64>() / values.len() as f64;

--- a/crates/pine-builtins/src/ta/volatility.rs
+++ b/crates/pine-builtins/src/ta/volatility.rs
@@ -1,311 +1,142 @@
+use super::moving_averages::{checked_length, smooth_step};
 use pine_builtin_macro::BuiltinFunction;
-use pine_interpreter::{Interpreter, PineOutput, RuntimeError, Value};
+use pine_interpreter::{Interpreter, PineOutput, RuntimeError, SeriesBuffer, Value};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// This bar's true range: `max(high - low, |high - close[1]|, |low - close[1]|)`.
+///
+/// `previous_close` is `None` on the first bar, where Pine falls back to
+/// `high - low` unless `handle_na` asks for na instead.
+fn true_range(high: f64, low: f64, previous_close: Option<f64>) -> Option<f64> {
+    match previous_close {
+        Some(close) => Some(
+            (high - low)
+                .max((high - close).abs())
+                .max((low - close).abs()),
+        ),
+        None => Some(high - low),
+    }
+}
+
+/// Reads this bar's high, low and close, which the range builtins all need.
+fn hlc<O: PineOutput>(ctx: &Interpreter<O>) -> Result<(f64, f64, f64), RuntimeError> {
+    let read = |name: &str| -> Result<f64, RuntimeError> {
+        ctx.get_variable(name)
+            .ok_or_else(|| RuntimeError::UndefinedVariable(name.to_string()))?
+            .as_number()
+    };
+    Ok((read("high")?, read("low")?, read("close")?))
+}
 
 /// ta.tr(handle_na) - True Range
-/// True range is max(high - low, abs(high - close[1]), abs(low - close[1]))
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.tr")]
+#[builtin(name = "ta.tr", stateful)]
 pub struct TaTr {
     #[arg(default = false)]
     handle_na: bool,
+    /// Previous bar's close, which the range is measured against.
+    #[state]
+    previous_close: Option<f64>,
 }
 
 impl TaTr {
-    fn execute<O: PineOutput>(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        // Get high, low, close from context
-        let high = ctx
-            .get_variable("high")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("high".to_string()))?;
-        let low = ctx
-            .get_variable("low")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("low".to_string()))?;
-        let close = ctx
-            .get_variable("close")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("close".to_string()))?;
+    fn execute<O: PineOutput>(
+        &mut self,
+        ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let (high, low, close) = hlc(ctx)?;
+        let previous_close = self.previous_close.replace(close);
 
-        let high_val = if let Value::Series(s) = high {
-            if let Value::Number(n) = *s.current {
-                n
-            } else {
-                return Err(RuntimeError::TypeError("high must be a number".to_string()));
-            }
-        } else if let Value::Number(n) = high {
-            *n
-        } else {
-            return Err(RuntimeError::TypeError(
-                "high must be a number or series".to_string(),
-            ));
-        };
-
-        let low_val = if let Value::Series(s) = low {
-            if let Value::Number(n) = *s.current {
-                n
-            } else {
-                return Err(RuntimeError::TypeError("low must be a number".to_string()));
-            }
-        } else if let Value::Number(n) = low {
-            *n
-        } else {
-            return Err(RuntimeError::TypeError(
-                "low must be a number or series".to_string(),
-            ));
-        };
-
-        // Get previous close
-        let prev_close = if let Value::Series(s) = close {
-            if let Some(provider) = &ctx.historical_provider {
-                if let Some(Value::Number(n)) = provider.get_historical(&s.id, 1) {
-                    Some(n)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // Calculate true range
-        let tr = if let Some(pc) = prev_close {
-            let hl = high_val - low_val;
-            let hc = (high_val - pc).abs();
-            let lc = (low_val - pc).abs();
-            hl.max(hc).max(lc)
-        } else {
-            // No previous close available
-            if self.handle_na {
-                high_val - low_val
-            } else {
-                return Ok(Value::Na);
-            }
-        };
-
-        Ok(Value::Number(tr))
-    }
-}
-
-/// ta.atr(length) - Average True Range
-#[derive(BuiltinFunction)]
-#[builtin(name = "ta.atr")]
-pub struct TaAtr {
-    length: f64,
-}
-
-impl TaAtr {
-    fn execute<O: PineOutput>(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
-
-        // Get high, low, close series from context
-        let high = ctx
-            .get_variable("high")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("high".to_string()))?;
-        let low = ctx
-            .get_variable("low")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("low".to_string()))?;
-        let close = ctx
-            .get_variable("close")
-            .ok_or_else(|| RuntimeError::UndefinedVariable("close".to_string()))?;
-
-        // We need to calculate TR for each bar and then RMA of those TRs
-        let mut tr_values = Vec::new();
-
-        // Calculate current TR
-        let current_tr = {
-            let high_val = if let Value::Series(s) = high {
-                if let Value::Number(n) = *s.current {
-                    n
-                } else {
-                    return Err(RuntimeError::TypeError(
-                        "high must contain numbers".to_string(),
-                    ));
-                }
-            } else if let Value::Number(n) = high {
-                *n
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "high must be a number or series".to_string(),
-                ));
-            };
-
-            let low_val = if let Value::Series(s) = low {
-                if let Value::Number(n) = *s.current {
-                    n
-                } else {
-                    return Err(RuntimeError::TypeError(
-                        "low must contain numbers".to_string(),
-                    ));
-                }
-            } else if let Value::Number(n) = low {
-                *n
-            } else {
-                return Err(RuntimeError::TypeError(
-                    "low must be a number or series".to_string(),
-                ));
-            };
-
-            let prev_close = if let Value::Series(s) = close {
-                if let Some(provider) = &ctx.historical_provider {
-                    if let Some(Value::Number(n)) = provider.get_historical(&s.id, 1) {
-                        Some(n)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            if let Some(pc) = prev_close {
-                let hl = high_val - low_val;
-                let hc = (high_val - pc).abs();
-                let lc = (low_val - pc).abs();
-                hl.max(hc).max(lc)
-            } else {
-                high_val - low_val
-            }
-        };
-
-        tr_values.push(current_tr);
-
-        // Get historical TR values
-        if let (Value::Series(high_s), Value::Series(low_s), Value::Series(close_s)) =
-            (high, low, close)
-        {
-            if let Some(provider) = &ctx.historical_provider {
-                for i in 1..length * 2 {
-                    let h = if let Some(Value::Number(n)) = provider.get_historical(&high_s.id, i) {
-                        n
-                    } else {
-                        break;
-                    };
-
-                    let l = if let Some(Value::Number(n)) = provider.get_historical(&low_s.id, i) {
-                        n
-                    } else {
-                        break;
-                    };
-
-                    let pc = if let Some(Value::Number(n)) =
-                        provider.get_historical(&close_s.id, i + 1)
-                    {
-                        Some(n)
-                    } else {
-                        None
-                    };
-
-                    let tr = if let Some(prev_c) = pc {
-                        let hl = h - l;
-                        let hc = (h - prev_c).abs();
-                        let lc = (l - prev_c).abs();
-                        hl.max(hc).max(lc)
-                    } else {
-                        h - l
-                    };
-
-                    tr_values.push(tr);
-                }
-            }
-        }
-
-        if tr_values.is_empty() {
+        // With no previous close, `handle_na = true` asks for na rather than
+        // falling back to the bar's own range.
+        if previous_close.is_none() && self.handle_na {
             return Ok(Value::Na);
         }
 
-        // Calculate RMA of TR values
-        let initial_sma: f64 = tr_values
-            .iter()
-            .take(length.min(tr_values.len()))
-            .sum::<f64>()
-            / length.min(tr_values.len()) as f64;
-        let mut rma = initial_sma;
-        let alpha = 1.0 / length as f64;
-
-        for &tr in tr_values
-            .iter()
-            .rev()
-            .skip(length.min(tr_values.len()))
-            .take(tr_values.len() - length.min(tr_values.len()))
-        {
-            rma = alpha * tr + (1.0 - alpha) * rma;
+        match true_range(high, low, previous_close) {
+            Some(tr) => Ok(Value::Number(tr)),
+            None => Ok(Value::Na),
         }
-
-        // Apply current TR
-        rma = alpha * tr_values[0] + (1.0 - alpha) * rma;
-
-        Ok(Value::Number(rma))
     }
 }
 
-/// ta.bb(series, length, mult) - Bollinger Bands
-/// Returns [middle, upper, lower] bands
+/// ta.atr(length) - Average True Range: Wilder-smoothed [`TaTr`].
 #[derive(BuiltinFunction)]
-#[builtin(name = "ta.bb")]
-pub struct TaBb<O: PineOutput> {
-    series: Value<O>,
+#[builtin(name = "ta.atr", stateful)]
+pub struct TaAtr {
+    length: f64,
+    #[state]
+    previous_close: Option<f64>,
+    #[state]
+    window: SeriesBuffer<f64>,
+    #[state]
+    previous: Option<f64>,
+}
+
+impl TaAtr {
+    fn execute<O: PineOutput>(
+        &mut self,
+        ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
+
+        let (high, low, close) = hlc(ctx)?;
+        let previous_close = self.previous_close.replace(close);
+        let Some(tr) = true_range(high, low, previous_close) else {
+            return Ok(Value::Na);
+        };
+
+        let Some(seed) = self.window.observe(tr, length) else {
+            return Ok(Value::Na);
+        };
+
+        let atr = smooth_step(self.previous, tr, 1.0 / length as f64, &seed);
+        self.previous = Some(atr);
+
+        Ok(Value::Number(atr))
+    }
+}
+
+/// ta.bb(series, length, mult) - Bollinger Bands, as `[middle, upper, lower]`.
+#[derive(BuiltinFunction)]
+#[builtin(name = "ta.bb", stateful)]
+pub struct TaBb {
+    series: f64,
     length: f64,
     mult: f64,
+    #[state]
+    window: SeriesBuffer<f64>,
 }
 
-impl<O: PineOutput> TaBb<O> {
-    fn execute(&self, ctx: &mut Interpreter<O>) -> Result<Value<O>, RuntimeError> {
-        let length = self.length as usize;
-        if length == 0 {
-            return Err(RuntimeError::TypeError(
-                "length must be greater than 0".to_string(),
-            ));
-        }
+impl TaBb {
+    fn execute<O: PineOutput>(
+        &mut self,
+        _ctx: &mut Interpreter<O>,
+    ) -> Result<Value<O>, RuntimeError> {
+        let length = checked_length(self.length)?;
 
-        // Get series values
-        let values = ctx.get_series_values(&self.series, length)?;
-
-        if values.is_empty() {
-            // Return tuple of [na, na, na]
-            let tuple = vec![Value::Na, Value::Na, Value::Na];
-            return Ok(Value::Array(std::rc::Rc::new(std::cell::RefCell::new(
-                tuple,
-            ))));
-        }
-
-        // Calculate basis (SMA)
-        let sum: f64 = values.iter().sum();
-        let basis = sum / values.len() as f64;
-
-        // Calculate standard deviation
-        let variance: f64 = if values.len() == 1 {
-            0.0
-        } else {
-            values
-                .iter()
-                .map(|&val| {
-                    let diff = val - basis;
-                    diff * diff
-                })
-                .sum::<f64>()
-                / values.len() as f64
+        let Some(values) = self.window.observe(self.series, length) else {
+            return Ok(bands(Value::Na, Value::Na, Value::Na));
         };
-        let stdev = variance.sqrt();
 
-        // Calculate bands
-        let dev = self.mult * stdev;
-        let upper = basis + dev;
-        let lower = basis - dev;
+        let basis: f64 = values.iter().sum::<f64>() / length as f64;
+        let variance: f64 = values
+            .iter()
+            .map(|value| (value - basis).powi(2))
+            .sum::<f64>()
+            / length as f64;
 
-        // Return tuple [middle, upper, lower]
-        let tuple = vec![
+        let deviation = self.mult * variance.sqrt();
+        Ok(bands(
             Value::Number(basis),
-            Value::Number(upper),
-            Value::Number(lower),
-        ];
-        Ok(Value::Array(std::rc::Rc::new(std::cell::RefCell::new(
-            tuple,
-        ))))
+            Value::Number(basis + deviation),
+            Value::Number(basis - deviation),
+        ))
     }
+}
+
+/// The `[middle, upper, lower]` tuple `ta.bb` returns.
+fn bands<O: PineOutput>(middle: Value<O>, upper: Value<O>, lower: Value<O>) -> Value<O> {
+    Value::Array(Rc::new(RefCell::new(vec![middle, upper, lower])))
 }

--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -1,4 +1,7 @@
 mod output;
+mod series_buffer;
+
+pub use series_buffer::{SeriesBuffer, MAX_LOOKBACK};
 
 // Re-export output types and traits
 pub use output::{
@@ -395,6 +398,9 @@ pub struct Interpreter<O: PineOutput> {
     /// Lexical id of the call site currently executing (0 at top level). Scopes
     /// `var` init-once tracking to the active call site.
     current_call_id: u32,
+    /// Counts bars executed. Stateful builtins compare against it to advance
+    /// their state at most once per bar, however often their call site runs.
+    bar_seq: u64,
 }
 
 /// Names a statement block ASSIGNS (declares or writes) directly — i.e. the true
@@ -465,6 +471,7 @@ impl<O: PineOutput> Interpreter<O> {
             function_local_state: HashMap::new(),
             var_decls_initialized: std::collections::HashSet::new(),
             current_call_id: 0,
+            bar_seq: 0,
         }
     }
 
@@ -482,6 +489,7 @@ impl<O: PineOutput> Interpreter<O> {
             function_local_state: HashMap::new(),
             var_decls_initialized: std::collections::HashSet::new(),
             current_call_id: 0,
+            bar_seq: 0,
         }
     }
 
@@ -499,6 +507,7 @@ impl<O: PineOutput> Interpreter<O> {
             function_local_state: HashMap::new(),
             var_decls_initialized: std::collections::HashSet::new(),
             current_call_id: 0,
+            bar_seq: 0,
         }
     }
 
@@ -519,7 +528,14 @@ impl<O: PineOutput> Interpreter<O> {
             function_local_state: HashMap::new(),
             var_decls_initialized: std::collections::HashSet::new(),
             current_call_id: 0,
+            bar_seq: 0,
         }
+    }
+
+    /// How many bars have been executed. A stateful builtin advances its state
+    /// when this differs from the value it last saw.
+    pub fn bar_seq(&self) -> u64 {
+        self.bar_seq
     }
 
     /// Set the historical data provider
@@ -541,6 +557,8 @@ impl<O: PineOutput> Interpreter<O> {
     pub fn execute(&mut self, program: &Program) -> Result<O, RuntimeError> {
         // Clear output from previous iteration
         self.output.clear();
+        // A new bar: stateful builtins may advance their state again.
+        self.bar_seq += 1;
 
         for stmt in &program.statements {
             self.execute_stmt(stmt)?;

--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -26,10 +26,21 @@ pub trait LibraryLoader {
     fn load_library(&self, path: &str) -> Result<Program, String>;
 }
 
-/// Trait for providing historical data for series
-pub trait HistoricalDataProvider<O: PineOutput = DefaultPineOutput> {
-    /// Get historical value for a series at a given offset (0 = current, 1 = previous bar, etc.)
-    fn get_historical(&self, series_id: &str, offset: usize) -> Option<Value<O>>;
+/// Record `value` as what `name` held on a completed bar, so `name[n]` can reach
+/// it. Entries beyond [`MAX_LOOKBACK`] are dropped.
+///
+/// Takes the history map rather than `&mut self` so callers can hold a borrow of
+/// another interpreter field while recording.
+fn push_history<O: PineOutput>(
+    history: &mut HashMap<String, Vec<Value<O>>>,
+    name: &str,
+    value: Value<O>,
+) {
+    let entries = history.entry(name.to_string()).or_default();
+    entries.push(value);
+    if entries.len() > MAX_LOOKBACK {
+        entries.drain(..entries.len() - MAX_LOOKBACK);
+    }
 }
 
 #[derive(Error, Debug)]
@@ -364,14 +375,10 @@ struct MethodDef {
 pub struct Interpreter<O: PineOutput> {
     /// Local variables in the current scope
     variables: HashMap<String, Variable<O>>,
-    /// Builtin function registry
-    builtins: HashMap<String, BuiltinFn<O>>,
     /// Method registry (method_name -> Vec<MethodDef>) - can have multiple methods with same name for different types
     methods: HashMap<String, Vec<MethodDef>>,
     /// Library loader for importing external libraries
     library_loader: Option<Box<dyn LibraryLoader>>,
-    /// Historical data provider for series lookback
-    pub historical_provider: Option<Box<dyn HistoricalDataProvider<O>>>,
     /// Exported items from this module (for library mode)
     exports: HashMap<String, Value<O>>,
     /// Output storage for plots, labels, logs, etc.
@@ -462,66 +469,7 @@ impl<O: PineOutput> Interpreter<O> {
         Self {
             variables: HashMap::new(),
             methods: HashMap::new(),
-            builtins: HashMap::new(),
             library_loader: None,
-            historical_provider: None,
-            exports: HashMap::new(),
-            output: O::default(),
-            user_series_history: HashMap::new(),
-            function_local_state: HashMap::new(),
-            var_decls_initialized: std::collections::HashSet::new(),
-            current_call_id: 0,
-            bar_seq: 0,
-        }
-    }
-
-    /// Create interpreter with custom builtins
-    pub fn with_builtins(builtins: HashMap<String, BuiltinFn<O>>) -> Self {
-        Self {
-            variables: HashMap::new(),
-            methods: HashMap::new(),
-            builtins,
-            library_loader: None,
-            historical_provider: None,
-            exports: HashMap::new(),
-            output: O::default(),
-            user_series_history: HashMap::new(),
-            function_local_state: HashMap::new(),
-            var_decls_initialized: std::collections::HashSet::new(),
-            current_call_id: 0,
-            bar_seq: 0,
-        }
-    }
-
-    /// Create interpreter with a library loader
-    pub fn with_loader(loader: Box<dyn LibraryLoader>) -> Self {
-        Self {
-            variables: HashMap::new(),
-            methods: HashMap::new(),
-            builtins: HashMap::new(),
-            library_loader: Some(loader),
-            historical_provider: None,
-            exports: HashMap::new(),
-            output: O::default(),
-            user_series_history: HashMap::new(),
-            function_local_state: HashMap::new(),
-            var_decls_initialized: std::collections::HashSet::new(),
-            current_call_id: 0,
-            bar_seq: 0,
-        }
-    }
-
-    /// Create interpreter with custom builtins and library loader
-    pub fn with_builtins_and_loader(
-        builtins: HashMap<String, BuiltinFn<O>>,
-        loader: Box<dyn LibraryLoader>,
-    ) -> Self {
-        Self {
-            variables: HashMap::new(),
-            methods: HashMap::new(),
-            builtins,
-            library_loader: Some(loader),
-            historical_provider: None,
             exports: HashMap::new(),
             output: O::default(),
             user_series_history: HashMap::new(),
@@ -536,11 +484,6 @@ impl<O: PineOutput> Interpreter<O> {
     /// when this differs from the value it last saw.
     pub fn bar_seq(&self) -> u64 {
         self.bar_seq
-    }
-
-    /// Set the historical data provider
-    pub fn set_historical_provider(&mut self, provider: Box<dyn HistoricalDataProvider<O>>) {
-        self.historical_provider = Some(provider);
     }
 
     /// Set the library loader
@@ -585,6 +528,25 @@ impl<O: PineOutput> Interpreter<O> {
         );
     }
 
+    /// Set a built-in series to its value for a new bar, keeping the outgoing
+    /// value reachable as `name[1]`.
+    ///
+    /// This is how the OHLCV series and their derivations get the same lookback
+    /// as any user variable: history accumulates as bars execute, so `close[1]`
+    /// is na until a second bar has run.
+    pub fn advance_series(&mut self, name: &str, value: Value<O>) {
+        if let Some(existing) = self.variables.get(name) {
+            // Record the number the series held, not the series wrapper, so a
+            // `name[1]` lookback reads as a plain value.
+            let previous = match &existing.value {
+                Value::Series(series) => (*series.current).clone(),
+                other => other.clone(),
+            };
+            push_history(&mut self.user_series_history, name, previous);
+        }
+        self.set_variable(name, value);
+    }
+
     /// Set a const variable (cannot be reassigned)
     pub fn set_const_variable(&mut self, name: &str, value: Value<O>) {
         self.variables.insert(
@@ -595,50 +557,6 @@ impl<O: PineOutput> Interpreter<O> {
                 is_var_persistent: false,
             },
         );
-    }
-
-    /// Helper to get series values as a Vec<f64> for the given length
-    /// Returns current value + historical values up to length-1
-    pub fn get_series_values(
-        &self,
-        source: &Value<O>,
-        length: usize,
-    ) -> Result<Vec<f64>, RuntimeError> {
-        let mut values = Vec::new();
-
-        match source {
-            Value::Series(series) => {
-                // Get current value
-                if let Value::Number(n) = *series.current {
-                    values.push(n);
-                } else {
-                    return Err(RuntimeError::TypeError(
-                        "Series must contain numbers".to_string(),
-                    ));
-                }
-
-                // Get historical values
-                if let Some(provider) = &self.historical_provider {
-                    for i in 1..length {
-                        if let Some(Value::Number(n)) = provider.get_historical(&series.id, i) {
-                            values.push(n);
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            }
-            Value::Number(n) => {
-                values.push(*n);
-            }
-            _ => {
-                return Err(RuntimeError::TypeError(
-                    "source must be a number or series".to_string(),
-                ));
-            }
-        }
-
-        Ok(values)
     }
 
     /// Helper to evaluate arguments and validate positional-before-named rule
@@ -704,11 +622,7 @@ impl<O: PineOutput> Interpreter<O> {
                 // the Assignment handler does for `:=` reassignments.
                 if !is_var_persistent {
                     if let Some(existing) = self.variables.get(name) {
-                        let hist = self.user_series_history.entry(name.clone()).or_default();
-                        hist.push(existing.value.clone());
-                        if hist.len() > 500 {
-                            hist.drain(..hist.len() - 500);
-                        }
+                        push_history(&mut self.user_series_history, name, existing.value.clone());
                     }
                 }
                 let value = if let Some(init_expr) = initializer {
@@ -736,11 +650,7 @@ impl<O: PineOutput> Interpreter<O> {
                 if let Expr::Variable(name) = target {
                     if let Some(var) = self.variables.get(name) {
                         if var.is_var_persistent {
-                            let hist = self.user_series_history.entry(name.clone()).or_default();
-                            hist.push(var.value.clone());
-                            if hist.len() > 500 {
-                                hist.drain(..hist.len() - 500);
-                            }
+                            push_history(&mut self.user_series_history, name, var.value.clone());
                         }
                     }
                 }
@@ -756,12 +666,11 @@ impl<O: PineOutput> Interpreter<O> {
                                 }
                                 if !var.is_var_persistent {
                                     // Non-var: push current value to history after eval (Pine [n] lookback).
-                                    let hist =
-                                        self.user_series_history.entry(name.clone()).or_default();
-                                    hist.push(var.value.clone());
-                                    if hist.len() > 500 {
-                                        hist.drain(..hist.len() - 500);
-                                    }
+                                    push_history(
+                                        &mut self.user_series_history,
+                                        name,
+                                        var.value.clone(),
+                                    );
                                 }
                                 // var-persistent: already pushed before eval above.
                                 (false, var.is_var_persistent)
@@ -818,11 +727,7 @@ impl<O: PineOutput> Interpreter<O> {
                     for (i, name) in names.iter().enumerate() {
                         // Push current value to history before overwriting (supports [n] lookback).
                         if let Some(var) = self.variables.get(name) {
-                            let hist = self.user_series_history.entry(name.clone()).or_default();
-                            hist.push(var.value.clone());
-                            if hist.len() > 500 {
-                                hist.drain(..hist.len() - 500);
-                            }
+                            push_history(&mut self.user_series_history, name, var.value.clone());
                         }
                         let element_val = arr.get(i).cloned().unwrap_or(Value::Na);
                         self.variables.insert(
@@ -1246,17 +1151,11 @@ impl<O: PineOutput> Interpreter<O> {
         match expr {
             Expr::Literal(lit) => Ok(self.eval_literal(lit)),
 
-            Expr::Variable(name) => {
-                // Check builtins first, then variables
-                if let Some(builtin_fn) = self.builtins.get(name).cloned() {
-                    Ok(Value::BuiltinFunction(builtin_fn))
-                } else {
-                    self.variables
-                        .get(name)
-                        .map(|var| var.value.clone())
-                        .ok_or_else(|| RuntimeError::UndefinedVariable(name.clone()))
-                }
-            }
+            Expr::Variable(name) => self
+                .variables
+                .get(name)
+                .map(|var| var.value.clone())
+                .ok_or_else(|| RuntimeError::UndefinedVariable(name.clone())),
 
             Expr::Binary {
                 left, op, right, ..
@@ -1368,14 +1267,14 @@ impl<O: PineOutput> Interpreter<O> {
                             .ok_or(RuntimeError::IndexOutOfBounds(index_val))
                     }
                     Value::Series(series) => {
-                        // For series, index 0 is current value, index > 0 queries historical provider
+                        // Index 0 is this bar. Anything further back lives in
+                        // `user_series_history`, which the branch above already
+                        // consulted for a named variable — reaching here means
+                        // the series has no recorded history, which is na.
                         if index_val == 0 {
                             Ok((*series.current).clone())
                         } else {
-                            self.historical_provider
-                                .as_ref()
-                                .and_then(|p| p.get_historical(&series.id, index_val))
-                                .ok_or(RuntimeError::IndexOutOfBounds(index_val))
+                            Ok(Value::Na)
                         }
                     }
                     ref v => Err(RuntimeError::TypeError(format!(

--- a/crates/pine-interpreter/src/series_buffer.rs
+++ b/crates/pine-interpreter/src/series_buffer.rs
@@ -1,0 +1,124 @@
+//! A rolling window of a series' past values, for stateful builtins.
+//!
+//! A builtin declares one as a `#[state]` field, so the buffer is owned by the
+//! call site and survives across bars. It records one value per bar (the macro's
+//! once-per-bar guard makes sure of that) and keeps only as many as the caller
+//! asks for, so a `ta.sma(close, 20)` call site holds 20 values rather than the
+//! whole chart.
+
+use std::collections::VecDeque;
+
+/// The most values any single call site retains. Matches the lookback Pine
+/// allows, and bounds memory when a script asks for an absurd length.
+pub const MAX_LOOKBACK: usize = 5000;
+
+/// A capped window of past values, newest first.
+#[derive(Debug, Clone)]
+pub struct SeriesBuffer<T> {
+    /// Newest first: `values[0]` is the current bar.
+    values: VecDeque<T>,
+}
+
+impl<T> Default for SeriesBuffer<T> {
+    fn default() -> Self {
+        Self {
+            values: VecDeque::new(),
+        }
+    }
+}
+
+impl<T> SeriesBuffer<T> {
+    /// Record this bar's value, retaining at most `capacity` of them.
+    pub fn push(&mut self, value: T, capacity: usize) {
+        self.values.push_front(value);
+        let capacity = capacity.clamp(1, MAX_LOOKBACK);
+        while self.values.len() > capacity {
+            self.values.pop_back();
+        }
+    }
+
+    /// The value `offset` bars back, or `None` if the buffer has not seen that
+    /// many bars yet. `offset` 0 is the current bar.
+    pub fn get(&self, offset: usize) -> Option<&T> {
+        self.values.get(offset)
+    }
+
+    /// How many bars are retained.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// The retained values, newest first.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.values.iter()
+    }
+}
+
+impl SeriesBuffer<f64> {
+    /// The newest `n` values, newest first. Shorter than `n` while warming up.
+    pub fn window(&self, n: usize) -> Vec<f64> {
+        self.values.iter().take(n).copied().collect()
+    }
+
+    /// Record this bar's value and return the `length` values to compute over,
+    /// newest first — or `None` while fewer than `length` bars have been seen.
+    ///
+    /// Pine yields na until a series has enough history to answer, so warming
+    /// up is the buffer's business rather than each builtin's.
+    pub fn observe(&mut self, value: f64, length: usize) -> Option<Vec<f64>> {
+        self.push(value, length);
+        (self.len() >= length).then(|| self.window(length))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_newest_values_up_to_capacity() {
+        let mut buf = SeriesBuffer::default();
+        for value in [1.0, 2.0, 3.0, 4.0] {
+            buf.push(value, 3);
+        }
+
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf.window(3), vec![4.0, 3.0, 2.0]);
+        assert_eq!(buf.get(0), Some(&4.0));
+        assert_eq!(buf.get(2), Some(&2.0));
+        assert_eq!(buf.get(3), None);
+    }
+
+    #[test]
+    fn window_is_short_while_warming_up() {
+        let mut buf = SeriesBuffer::default();
+        buf.push(1.0, 5);
+        buf.push(2.0, 5);
+
+        assert_eq!(buf.window(5), vec![2.0, 1.0]);
+    }
+
+    #[test]
+    fn observe_withholds_a_window_until_it_fills() {
+        let mut buf = SeriesBuffer::default();
+
+        assert_eq!(buf.observe(1.0, 3), None);
+        assert_eq!(buf.observe(2.0, 3), None);
+        assert_eq!(buf.observe(3.0, 3), Some(vec![3.0, 2.0, 1.0]));
+        assert_eq!(buf.observe(4.0, 3), Some(vec![4.0, 3.0, 2.0]));
+    }
+
+    #[test]
+    fn capacity_is_bounded_by_max_lookback() {
+        let mut buf = SeriesBuffer::default();
+        for value in 0..(MAX_LOOKBACK + 10) {
+            buf.push(value as f64, usize::MAX);
+        }
+
+        assert_eq!(buf.len(), MAX_LOOKBACK);
+    }
+}

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -9,9 +9,9 @@ use pine_ast::Program;
 use pine_core::{PineVersion, SymInfo, Timeframe, VersionError};
 use pine_diagnostics::Diagnostic;
 use pine_interpreter::{
-    AlertConditionOutput, Bar, BoxOutput, FillOutput, GlobalOutput, HistoricalDataProvider,
-    IndicatorOutput, InputOutput, Interpreter, LabelOutput, LibraryLoader, LineOutput, LogOutput,
-    PineOutput, PlotOutput, RuntimeError, TableOutput, Value,
+    AlertConditionOutput, Bar, BoxOutput, FillOutput, GlobalOutput, IndicatorOutput, InputOutput,
+    Interpreter, LabelOutput, LibraryLoader, LineOutput, LogOutput, PineOutput, PlotOutput,
+    RuntimeError, TableOutput, Value,
 };
 use pine_lexer::{Lexer, LexerError};
 use pine_parser::{Parser, ParserError};
@@ -81,7 +81,6 @@ impl From<VersionError> for Error {
 pub struct ScriptBuilder<O: PineOutput> {
     source: String,
     custom_variables: HashMap<String, Value<O>>,
-    historical_provider: Option<Box<dyn HistoricalDataProvider<O>>>,
     library_loader: Option<Box<dyn LibraryLoader>>,
     syminfo: Option<SymInfo>,
     timeframe: Option<Timeframe>,
@@ -92,7 +91,6 @@ impl<O: PineOutput> ScriptBuilder<O> {
         Self {
             source: source.to_string(),
             custom_variables: HashMap::new(),
-            historical_provider: None,
             library_loader: None,
             syminfo: None,
             timeframe: None,
@@ -103,14 +101,6 @@ impl<O: PineOutput> ScriptBuilder<O> {
     /// alongside the builtin namespaces.
     pub fn with_custom_variables(mut self, variables: HashMap<String, Value<O>>) -> Self {
         self.custom_variables = variables;
-        self
-    }
-
-    pub fn with_historical_provider(
-        mut self,
-        provider: Box<dyn HistoricalDataProvider<O>>,
-    ) -> Self {
-        self.historical_provider = Some(provider);
         self
     }
 
@@ -194,9 +184,6 @@ impl<O: PineOutput> ScriptBuilder<O> {
 
         // Create interpreter and load builtin namespace objects
         let mut interpreter = Interpreter::new();
-        if let Some(historical_provider) = self.historical_provider {
-            interpreter.set_historical_provider(historical_provider);
-        }
         if let Some(library_loader) = self.library_loader {
             interpreter.set_library_loader(library_loader);
         }
@@ -243,7 +230,7 @@ impl<O: PineOutput> Script<O> {
             ("hlcc4", (bar.high + bar.low + bar.close * 2.0) / 4.0),
             ("ohlc4", (bar.open + bar.high + bar.low + bar.close) / 4.0),
         ] {
-            self.interpreter.set_variable(
+            self.interpreter.advance_series(
                 id,
                 Value::Series(Series {
                     id: id.to_string(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,15 +4,12 @@ mod tests {
     use pine_ast::Program;
     use pine_core::{SymInfo, Timeframe, TimeframeUnit};
     use pine_interpreter::{
-        AlertConditionOutput, Bar, DefaultPineOutput, HistoricalDataProvider, LibraryLoader,
-        LogOutput, Value,
+        AlertConditionOutput, Bar, DefaultPineOutput, LibraryLoader, LogOutput,
     };
     use pine_lexer::Lexer;
     use pine_parser::Parser;
-    use std::cell::Cell;
     use std::fs;
     use std::path::Path;
-    use std::rc::Rc;
 
     /// Generate synthetic OHLCV bar data for testing
     fn generate_test_bars(count: usize) -> Vec<Bar> {
@@ -41,62 +38,6 @@ mod tests {
         }
 
         bars
-    }
-
-    /// Mock historical data provider for tests
-    struct TestHistoricalData {
-        bars: Vec<Bar>,
-        current_index: Rc<Cell<usize>>,
-    }
-
-    impl TestHistoricalData {
-        fn new(bars: Vec<Bar>) -> Self {
-            Self {
-                bars,
-                current_index: Rc::new(Cell::new(0)),
-            }
-        }
-
-        /// Shared handle to the "current bar" index so the caller can advance it
-        /// between executions after the provider has been moved into the script.
-        fn current_handle(&self) -> Rc<Cell<usize>> {
-            self.current_index.clone()
-        }
-    }
-
-    impl HistoricalDataProvider<DefaultPineOutput> for TestHistoricalData {
-        fn get_historical(
-            &self,
-            series_id: &str,
-            offset: usize,
-        ) -> Option<Value<DefaultPineOutput>> {
-            let current_index = self.current_index.get();
-
-            if current_index < offset {
-                return None;
-            }
-
-            let bar_index = current_index - offset;
-            if bar_index >= self.bars.len() {
-                return None;
-            }
-
-            let bar = &self.bars[bar_index];
-            let value = match series_id {
-                "open" => bar.open,
-                "high" => bar.high,
-                "low" => bar.low,
-                "close" => bar.close,
-                "volume" => bar.volume,
-                "hl2" => (bar.high + bar.low) / 2.0,
-                "hlc3" => (bar.high + bar.low + bar.close) / 3.0,
-                "hlcc4" => (bar.high + bar.low + bar.close * 2.0) / 4.0,
-                "ohlc4" => (bar.open + bar.high + bar.low + bar.close) / 4.0,
-                _ => return None,
-            };
-
-            Some(Value::Number(value))
-        }
     }
 
     enum ExpectedResult {
@@ -228,29 +169,25 @@ mod tests {
     fn execute_pine_script_with_logger(source: &str) -> eyre::Result<Vec<String>> {
         let library_loader = TestLibraryLoader::new();
 
-        // Generate historical bar data for TA functions
         let bars = generate_test_bars(200);
-        let historical_data = TestHistoricalData::new(bars.clone());
-        let current_index = historical_data.current_handle();
 
-        let mut script = ScriptBuilder::with_code(source)
+        let mut script = ScriptBuilder::<DefaultPineOutput>::with_code(source)
             .with_library_loader(Box::new(library_loader))
-            .with_historical_provider(Box::new(historical_data))
             .with_syminfo(test_syminfo())
             .with_timeframe(test_timeframe())
             .compile()?;
 
         // Run over the final `bar_count` bars, keeping interpreter state across
         // them, and collect every log emitted. `// Bars: N` opts into multi-bar
-        // execution to exercise cross-bar state (`var` persistence, user-series
-        // history, stateful function locals); the default is the last bar only.
+        // execution, which is what builds series history and stateful builtins'
+        // windows — a fixture reaching back with `close[1]` or calling `ta.sma`
+        // needs enough bars to fill. The default is the last bar only.
         let bar_count = extract_bar_count(source).unwrap_or(1).min(bars.len());
         let start = bars.len() - bar_count;
 
         let mut logs = Vec::new();
         let mut last_output = None;
-        for (index, bar) in bars.iter().enumerate().skip(start) {
-            current_index.set(index);
+        for bar in bars.iter().skip(start) {
             let pine_output = script.execute(bar)?;
             logs.extend(pine_output.get_logs().iter().map(|log| log.message.clone()));
             last_output = Some(pine_output);

--- a/tests/testdata/series/derived_prices.pine
+++ b/tests/testdata/series/derived_prices.pine
@@ -1,6 +1,9 @@
-// The derived price series are set per bar alongside OHLCV, and carry a series
-// id so they index into history like close does.
-// Current bar: open = 299, high = 304, low = 294, close = 301.
+// The derived price series are set per bar alongside OHLCV, and their history
+// accumulates as bars execute — so `hl2[1]` is na until a second bar has run.
+// Previous bar: open = 298, high = 303, low = 293, close = 300.
+// Current bar:  open = 299, high = 304, low = 294, close = 301.
+
+// Bars: 2
 
 // (304 + 294) / 2
 log.info(hl2[0])
@@ -14,10 +17,15 @@ log.info(hlcc4[0])
 // (299 + 304 + 294 + 301) / 4
 log.info(ohlc4[0])
 
-// Previous bar: high = 303, low = 293
+// (303 + 293) / 2, and na on the first bar
 log.info(hl2[1])
 
 // Expected output:
+// 298
+// 298.6666666666667
+// 299
+// 298.5
+// na
 // 299
 // 299.6666666666667
 // 300

--- a/tests/testdata/series/expressions.pine
+++ b/tests/testdata/series/expressions.pine
@@ -1,23 +1,36 @@
 // Test using series in expressions
-// Bar 199: close=301, Bar 198: close=300, Bar 197: close=299
+//
+// Lookbacks read from history built as bars execute, so an expression reaching
+// back is na until enough bars have run. Over the last 3 bars close is
+// 299, 300, 301.
 
-// Calculate change from previous bar
+// Bars: 3
+
+// Change from the previous bar
 change = close[0] - close[1]
 log.info(change)
 
-// Calculate average of current and previous
+// Average of this bar and the previous one
 avg = (close[0] + close[1]) / 2
 log.info(avg)
 
-// Check if price is rising
+// Comparing against a missing bar is na, not false
 is_rising = close[0] > close[1]
 log.info(is_rising)
 
-// Calculate sum of last 3 bars
+// Sum over 3 bars needs all three of them
 sum3 = close[0] + close[1] + close[2]
 log.info(sum3)
 
 // Expected output:
+// na
+// na
+// na
+// na
+// 1
+// 299.5
+// true
+// na
 // 1
 // 300.5
 // true

--- a/tests/testdata/series/indexing.pine
+++ b/tests/testdata/series/indexing.pine
@@ -1,25 +1,26 @@
 // Test series indexing (accessing historical values)
-// The test framework provides 200 bars of historical data
-// Bar 199 (current): close = 301, Bar 198: close = 300, Bar 197: close = 299
+//
+// A series' history accumulates as bars execute, so a lookback deeper than the
+// number of bars run so far is na. Over the last 3 bars close is 299, 300, 301.
 
-// Access current value (index 0)
-current = close[0]
-log.info(current)
+// Bars: 3
 
-// Access previous bar (index 1)
-prev1 = close[1]
-log.info(prev1)
+// Current bar
+log.info(close[0])
 
-// Access 2 bars ago (index 2)
-prev2 = close[2]
-log.info(prev2)
+// Previous bar — na until a second bar has run
+log.info(close[1])
 
-// Access 5 bars ago (index 5)
-prev5 = close[5]
-log.info(prev5)
+// Two bars back — na until a third has run
+log.info(close[2])
 
 // Expected output:
+// 299
+// na
+// na
+// 300
+// 299
+// na
 // 301
 // 300
 // 299
-// 296

--- a/tests/testdata/ta/atr.pine
+++ b/tests/testdata/ta/atr.pine
@@ -1,16 +1,16 @@
 // Test ta.atr (Average True Range)
-// ATR is the RMA (moving average) of True Range values
-// Uses historical high, low, close values to calculate TR for each bar
-// Then applies RMA smoothing
+// Wilder-smoothed true range, so it is na until `length` bars have been seen
+// and then starts from their simple average. Every fixture bar has a true
+// range of exactly 10, so the average is 10 too.
 
-// ATR with period 5
+// Bars: 5
+
 atr5 = ta.atr(5)
 log.info(atr5)
 
-// ATR with period 14 (common default)
-atr14 = ta.atr(14)
-log.info(atr14)
-
 // Expected output:
-// 10
+// na
+// na
+// na
+// na
 // 10

--- a/tests/testdata/ta/bb.pine
+++ b/tests/testdata/ta/bb.pine
@@ -1,38 +1,30 @@
 // Test ta.bb (Bollinger Bands)
-// Uses generated bars: bar[i] has close = 100 + i + 2 = 102 + i
-// For bar 199 (last bar): close = 301, bar 198: close = 300, etc.
+// Over the last 5 bars close is 297..301, so the basis is 299 and the
+// population variance is (4+1+0+1+4)/5 = 2, giving stdev sqrt(2).
+// With mult 2 the bands sit 2.8284271247461903 either side of the basis.
+//
+// While warming up all three bands are na together.
 
-// BB with length=5, mult=2
-// Last 5 closes: [301, 300, 299, 298, 297]
-// Middle (SMA): (301+300+299+298+297)/5 = 299
-// Variance: sum((x - 299)^2) / 5 = (4+1+0+1+4)/5 = 2
-// Stdev: sqrt(2) = 1.4142135623730951
-// Upper: 299 + 2*1.4142135623730951 = 301.8284271247462
-// Lower: 299 - 2*1.4142135623730951 = 296.1715728752538
+// Bars: 5
+
 [middle, upper, lower] = ta.bb(close, 5, 2)
 log.info(middle)
 log.info(upper)
 log.info(lower)
 
-// BB with length=10, mult=1
-// Last 10 closes: [301, 300, 299, 298, 297, 296, 295, 294, 293, 292]
-// Middle (SMA): 296.5
-// Variance: sum((x - 296.5)^2) / 10
-//  = ((4.5)^2 + (3.5)^2 + (2.5)^2 + (1.5)^2 + (0.5)^2 + (-0.5)^2 + (-1.5)^2 + (-2.5)^2 + (-3.5)^2 + (-4.5)^2) / 10
-//  = (20.25 + 12.25 + 6.25 + 2.25 + 0.25 + 0.25 + 2.25 + 6.25 + 12.25 + 20.25) / 10
-//  = 82.5 / 10 = 8.25
-// Stdev: sqrt(8.25) = 2.8722813232690143
-// Upper: 296.5 + 1*2.8722813232690143 = 299.3722813232690143
-// Lower: 296.5 - 1*2.8722813232690143 = 293.6277186767310
-[middle2, upper2, lower2] = ta.bb(close, 10, 1)
-log.info(middle2)
-log.info(upper2)
-log.info(lower2)
-
 // Expected output:
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
 // 299
 // 301.8284271247462
 // 296.1715728752538
-// 296.5
-// 299.372281323269
-// 293.627718676731

--- a/tests/testdata/ta/cci.pine
+++ b/tests/testdata/ta/cci.pine
@@ -1,17 +1,16 @@
 // Test ta.cci (Commodity Channel Index)
-// CCI = (Typical Price - SMA) / (0.015 * Mean Deviation)
-// Last 5 closes at bar 199: 301, 300, 299, 298, 297
-// SMA = 299, Current = 301, MAD = 1.2
-// CCI = (301 - 299) / (0.015 * 1.2) = 2 / 0.018 = 111.11...
+// (source - sma) / (0.015 * mean absolute deviation) over the window.
+// Over the last 5 bars close is 297..301, so sma = 299 and mad = 1.2.
 
-// CCI with period 5
+// Bars: 5
+
+// (301 - 299) / (0.015 * 1.2) = 2 / 0.018
 cci5 = ta.cci(close, 5)
 log.info(cci5)
 
-// CCI with period 10
-cci10 = ta.cci(close, 10)
-log.info(cci10)
-
 // Expected output:
+// na
+// na
+// na
+// na
 // 111.11111111111111
-// 120

--- a/tests/testdata/ta/change.pine
+++ b/tests/testdata/ta/change.pine
@@ -1,19 +1,19 @@
 // Test ta.change (Difference between current and N bars ago)
-// Bar 199: close = 301, Bar 198: close = 300, Bar 197: close = 299
+// Close rises by 1 each bar, so every change equals the bar distance once
+// enough bars have been seen.
 
-// Change from 1 bar ago
+// Bars: 3
+
 change1 = ta.change(close, 1)
 log.info(change1)
 
-// Change from 2 bars ago
 change2 = ta.change(close, 2)
 log.info(change2)
 
-// Change from 5 bars ago
-change5 = ta.change(close, 5)
-log.info(change5)
-
 // Expected output:
+// na
+// na
+// 1
+// na
 // 1
 // 2
-// 5

--- a/tests/testdata/ta/cmo.pine
+++ b/tests/testdata/ta/cmo.pine
@@ -1,18 +1,17 @@
 // Test ta.cmo (Chande Momentum Oscillator)
-// CMO = 100 * (sum of gains - sum of losses) / (sum of gains + sum of losses)
-// Last 5 closes: 301, 300, 299, 298, 297 (all gains, no losses)
-// Changes: +1, +1, +1, +1 (4 gains of 1 each)
-// sum_gains = 4, sum_losses = 0
-// CMO = 100 * (4 - 0) / (4 + 0) = 100
+// 100 * (gains - losses) / (gains + losses) over the last N changes, which
+// needs N+1 values. Close only ever rises here, so there are no losses.
 
-// CMO over 5 bars
+// Bars: 6
+
+// 5 gains of 1, no losses -> 100 * 5 / 5
 cmo5 = ta.cmo(close, 5)
 log.info(cmo5)
 
-// CMO over 10 bars
-cmo10 = ta.cmo(close, 10)
-log.info(cmo10)
-
 // Expected output:
-// 100
+// na
+// na
+// na
+// na
+// na
 // 100

--- a/tests/testdata/ta/cum.pine
+++ b/tests/testdata/ta/cum.pine
@@ -1,19 +1,26 @@
-// Test ta.cum (cumulative sum from the first bar)
-// The fixture has 200 bars: close = 102 + i, volume = 1000 + 10i (i = 0..199)
+// Test ta.cum (running total from the first executed bar)
+// `cum` accumulates as bars execute rather than reading back through history,
+// so it is asserted across bars. Over the last 3 bars close is 299, 300, 301
+// and volume is 2970, 2980, 2990.
 
-// Sum of every close: 200 * 102 + (0 + 1 + ... + 199) = 20400 + 19900
-cumClose = ta.cum(close)
-log.info(cumClose)
+// Bars: 3
 
-// Sum of every volume: 200 * 1000 + 10 * 19900
-cumVolume = ta.cum(volume)
-log.info(cumVolume)
+// 299, then 299+300, then 299+300+301
+log.info(ta.cum(close))
 
-// A plain number has no history, so it contributes only the current bar.
-cumConst = ta.cum(3)
-log.info(cumConst)
+// 2970, then 2970+2980, then 2970+2980+2990
+log.info(ta.cum(volume))
+
+// A constant still accumulates once per bar.
+log.info(ta.cum(1))
 
 // Expected output:
-// 40300
-// 399000
+// 299
+// 2970
+// 1
+// 599
+// 5950
+// 2
+// 900
+// 8940
 // 3

--- a/tests/testdata/ta/cum_per_call_site.pine
+++ b/tests/testdata/ta/cum_per_call_site.pine
@@ -1,0 +1,36 @@
+// A stateful builtin keeps its memory per CALL SITE, so two `ta.cum` calls
+// accumulate independently even though they are the same function.
+// Over the last 3 bars close is 299, 300, 301 and open is 297, 298, 299.
+
+// Bars: 3
+
+a = ta.cum(close)
+b = ta.cum(open)
+log.info(a)
+log.info(b)
+
+// A third call site over the same series keeps its own total, which happens to
+// track `a` because it sums the same values.
+c = ta.cum(close)
+log.info(c)
+
+// One call site reached twice in a single bar advances its total once, not
+// twice: the second pass gets back the value the first pass produced.
+looped = 0.0
+for i = 0 to 1
+    looped := ta.cum(close)
+log.info(looped)
+
+// Expected output:
+// 299
+// 297
+// 299
+// 299
+// 599
+// 595
+// 599
+// 599
+// 900
+// 894
+// 900
+// 900

--- a/tests/testdata/ta/dev.pine
+++ b/tests/testdata/ta/dev.pine
@@ -1,16 +1,13 @@
 // Test ta.dev (Mean Absolute Deviation)
-// MAD measures average distance from the mean
-// Last 5 closes: 297, 298, 299, 300, 301
-// Mean = 299, MAD = (2+1+0+1+2)/5 = 1.2
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301: mean 300, so (1 + 0 + 1) / 3.
 
-// Mean Absolute Deviation of last 5 closes
-dev5 = ta.dev(close, 5)
-log.info(dev5)
+// Bars: 3
 
-// Mean Absolute Deviation of last 10 closes
-dev10 = ta.dev(close, 10)
-log.info(dev10)
+d = ta.dev(close, 3)
+log.info(d)
 
 // Expected output:
-// 1.2
-// 2.5
+// na
+// na
+// 0.6666666666666666

--- a/tests/testdata/ta/ema.pine
+++ b/tests/testdata/ta/ema.pine
@@ -1,14 +1,21 @@
 // Test ta.ema (Exponential Moving Average)
-// EMA gives more weight to recent prices
+// Like Pine, na until `length` bars have been seen, then seeded with their
+// simple average and recursed with alpha * source + (1 - alpha) * ema[1].
+// Over the last 5 bars close is 297, 298, 299, 300, 301.
+//
+// Length 3 gives alpha = 2/(3+1) = 0.5, so the arithmetic is exact:
+//   bar 3 seeds with mean(297,298,299)     -> 298
+//   bar 4: 0.5*300 + 0.5*298               -> 299
+//   bar 5: 0.5*301 + 0.5*299               -> 300
 
-// EMA of last 10 closes
-ema10 = ta.ema(close, 10)
-log.info(ema10)
+// Bars: 5
 
-// EMA of last 20 closes
-ema20 = ta.ema(close, 20)
-log.info(ema20)
+ema3 = ta.ema(close, 3)
+log.info(ema3)
 
 // Expected output:
-// 298.4180688134034
-// 294.8496018136784
+// na
+// na
+// 298
+// 299
+// 300

--- a/tests/testdata/ta/highest_lowest.pine
+++ b/tests/testdata/ta/highest_lowest.pine
@@ -1,37 +1,19 @@
-// Test ta.highest and ta.lowest
-// Over the last 5 bars close is 297, 298, 299, 300, 301.
+// Test ta.highest and ta.lowest — the extreme VALUE over the window.
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301.
 
-// Bars: 5
+// Bars: 3
 
-high5 = ta.highest(close, 5)
-log.info(high5)
+high3 = ta.highest(close, 3)
+log.info(high3)
 
-low5 = ta.lowest(close, 5)
-log.info(low5)
-
-// Offsets are reported as negative bar counts back from the current bar. Close
-// only rises, so the highest is always this bar and the lowest the oldest one.
-log.info(ta.highestbars(close, 5))
-log.info(ta.lowestbars(close, 5))
+low3 = ta.lowest(close, 3)
+log.info(low3)
 
 // Expected output:
 // na
 // na
 // na
 // na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
-// na
 // 301
-// 297
-// 0
-// -4
+// 299

--- a/tests/testdata/ta/highest_lowest.pine
+++ b/tests/testdata/ta/highest_lowest.pine
@@ -1,24 +1,37 @@
 // Test ta.highest and ta.lowest
-// Last 10 closes: 301, 300, 299, 298, 297, 296, 295, 294, 293, 292
+// Over the last 5 bars close is 297, 298, 299, 300, 301.
 
-// Highest of last 10 closes
-high10 = ta.highest(close, 10)
-log.info(high10)
+// Bars: 5
 
-// Lowest of last 10 closes
-low10 = ta.lowest(close, 10)
-log.info(low10)
-
-// Highest of last 5 closes
 high5 = ta.highest(close, 5)
 log.info(high5)
 
-// Lowest of last 5 closes
 low5 = ta.lowest(close, 5)
 log.info(low5)
 
+// Offsets are reported as negative bar counts back from the current bar. Close
+// only rises, so the highest is always this bar and the lowest the oldest one.
+log.info(ta.highestbars(close, 5))
+log.info(ta.lowestbars(close, 5))
+
 // Expected output:
-// 301
-// 292
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
 // 301
 // 297
+// 0
+// -4

--- a/tests/testdata/ta/highestbars_lowestbars.pine
+++ b/tests/testdata/ta/highestbars_lowestbars.pine
@@ -1,0 +1,19 @@
+// Test ta.highestbars and ta.lowestbars — WHERE the extreme sits, not what it
+// is. Both report an offset back from the current bar: 0 is this bar, -1 the
+// one before it, and so on, so the result is always zero or negative.
+//
+// Over the last 3 bars close is 299, 300, 301. Close only ever rises here, so
+// the highest is this bar (0) and the lowest is the oldest in the window (-2).
+
+// Bars: 3
+
+log.info(ta.highestbars(close, 3))
+log.info(ta.lowestbars(close, 3))
+
+// Expected output:
+// na
+// na
+// na
+// na
+// 0
+// -2

--- a/tests/testdata/ta/hma.pine
+++ b/tests/testdata/ta/hma.pine
@@ -1,15 +1,29 @@
 // Test ta.hma (Hull Moving Average)
-// HMA = WMA(2 * WMA(n/2) - WMA(n), sqrt(n))
-// Reduces lag and improves smoothing
+// wma(2 * wma(source, length/2) - wma(source, length), sqrt(length)), so it
+// needs `length` bars for the inner averages and sqrt(length)-1 more for the
+// outer one: 9 + 2 = 11 bars here.
+//
+// A weighted average of a straight line lags it by (n-1)/3, so for this
+// fixture's close = 102 + i the whole expression collapses back onto close:
+//   inner  = 2*(c - 1) - (c - 8/3) = c + 2/3
+//   outer  = (c + 2/3) - 2/3      = c
+// which is the point of the Hull average — no lag on a trend. The expected
+// value below is 301 carrying the float error of the two weighted averages.
 
-// HMA with period 9
+// Bars: 11
+
 hma9 = ta.hma(close, 9)
 log.info(hma9)
 
-// HMA with period 16
-hma16 = ta.hma(close, 16)
-log.info(hma16)
-
 // Expected output:
-// 301.6666666666667
-// 301.33333333333337
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// na
+// 301.00000000000006

--- a/tests/testdata/ta/linreg.pine
+++ b/tests/testdata/ta/linreg.pine
@@ -1,16 +1,15 @@
 // Test ta.linreg (Linear Regression)
-// Linear regression fits a line through the data points
-// Last 5 closes: 297, 298, 299, 300, 301 (perfect uptrend, slope = 1)
-// At offset 0 (current bar), linreg should return value on the trend line
+// Over the last 5 bars close is 297..301 — a perfect uptrend with slope 1, so
+// the fitted line passes exactly through the current bar.
 
-// Linear regression over 5 bars at current offset
+// Bars: 5
+
 linreg5 = ta.linreg(close, 5, 0)
 log.info(linreg5)
 
-// Linear regression over 10 bars at current offset
-linreg10 = ta.linreg(close, 10, 0)
-log.info(linreg10)
-
 // Expected output:
-// 301
+// na
+// na
+// na
+// na
 // 301

--- a/tests/testdata/ta/median.pine
+++ b/tests/testdata/ta/median.pine
@@ -1,18 +1,21 @@
 // Test ta.median (Median value)
-// Median is the middle value when data is sorted
-// Last 5 closes: 297, 298, 299, 300, 301 (sorted)
-// Median = 299 (middle value)
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301.
 
-// Median of last 5 closes (odd number)
-med5 = ta.median(close, 5)
-log.info(med5)
+// Bars: 3
 
-// Median of last 4 closes (even number)
-// Last 4 closes: 298, 299, 300, 301 (sorted)
-// Median = (299 + 300) / 2 = 299.5
-med4 = ta.median(close, 4)
-log.info(med4)
+// Window [299,300,301] -> the middle value
+med3 = ta.median(close, 3)
+log.info(med3)
+
+// Fills a bar earlier; even-sized windows average the middle two
+med2 = ta.median(close, 2)
+log.info(med2)
 
 // Expected output:
-// 299
+// na
+// na
+// na
 // 299.5
+// 300
+// 300.5

--- a/tests/testdata/ta/mfi.pine
+++ b/tests/testdata/ta/mfi.pine
@@ -1,13 +1,24 @@
 // Test ta.mfi (Money Flow Index)
-// Every fixture bar closes higher than the last, so all money flow is positive
-// and the negative side stays at 0 — the saturated end of the index.
-mfi14 = ta.mfi(close, 14)
-log.info(mfi14)
+// Each bar's money flow is signed by the direction of the source, so the first
+// bar has no direction and `length` flows are needed after that.
 
-// A plain number has no history, so no bar has a predecessor to compare against.
-mfiConst = ta.mfi(3, 14)
-log.info(mfiConst)
+// Bars: 4
+
+// Every fixture bar closes higher than the last, so all flow is positive and
+// the negative side stays at 0 — the saturated end of the index.
+mfiUp = ta.mfi(close, 3)
+log.info(mfiUp)
+
+// Negating the source makes every bar a down bar, saturating at the other end.
+mfiDown = ta.mfi(-close, 3)
+log.info(mfiDown)
 
 // Expected output:
-// 100
 // na
+// na
+// na
+// na
+// na
+// na
+// 100
+// 0

--- a/tests/testdata/ta/mom.pine
+++ b/tests/testdata/ta/mom.pine
@@ -1,17 +1,17 @@
 // Test ta.mom (Momentum)
-// Momentum = Current - Value N bars ago
-// Current close = 301 (bar 199)
-// 5 bars ago = 296 (bar 194)
-// mom(5) = 301 - 296 = 5
+// Reaching 5 bars back needs 6 values, so like Pine this is na until the
+// window fills. Over the last 6 bars close is 296..301.
 
-// Momentum over 5 bars
+// Bars: 6
+
+// 301 - 296
 mom5 = ta.mom(close, 5)
 log.info(mom5)
 
-// Momentum over 10 bars
-mom10 = ta.mom(close, 10)
-log.info(mom10)
-
 // Expected output:
+// na
+// na
+// na
+// na
+// na
 // 5
-// 10

--- a/tests/testdata/ta/percentile_nearest_rank.pine
+++ b/tests/testdata/ta/percentile_nearest_rank.pine
@@ -1,24 +1,28 @@
 // Test ta.percentile_nearest_rank (percentile by the nearest-rank method)
-// Last 5 closes sorted ascending: 297, 298, 299, 300, 301
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301, so the sorted window is [299, 300, 301].
 
-// Median: rank = ceil(50/100 * 5) = 3 -> the 3rd smallest
-p50 = ta.percentile_nearest_rank(close, 5, 50)
+// Bars: 3
+
+// rank = ceil(50/100 * 3) = 2 -> the 2nd smallest
+p50 = ta.percentile_nearest_rank(close, 3, 50)
 log.info(p50)
 
-// rank = ceil(20/100 * 5) = 1 -> the smallest
-p20 = ta.percentile_nearest_rank(close, 5, 20)
-log.info(p20)
-
-// rank = ceil(100/100 * 5) = 5 -> the largest
-p100 = ta.percentile_nearest_rank(close, 5, 100)
+// rank = 3 -> the largest
+p100 = ta.percentile_nearest_rank(close, 3, 100)
 log.info(p100)
 
-// rank = 0 clamps up to 1 -> the smallest
-p0 = ta.percentile_nearest_rank(close, 5, 0)
+// rank 0 clamps up to 1 -> the smallest
+p0 = ta.percentile_nearest_rank(close, 3, 0)
 log.info(p0)
 
 // Expected output:
-// 299
-// 297
+// na
+// na
+// na
+// na
+// na
+// na
+// 300
 // 301
-// 297
+// 299

--- a/tests/testdata/ta/rising_falling.pine
+++ b/tests/testdata/ta/rising_falling.pine
@@ -1,19 +1,22 @@
 // Test ta.rising and ta.falling
-// close values: 299, 300, 301 (bar 197, 198, 199 - always increasing)
+// Testing 3 bars of movement needs 4 values. Unlike the windowed averages these
+// answer false rather than na while warming up, since they return a bool.
+// Close rises every bar in this fixture.
 
-// Check if close is rising for last 3 bars (should be true)
+// Bars: 4
+
 is_rising = ta.rising(close, 3)
 log.info(is_rising)
 
-// Check if close is falling for last 3 bars (should be false, it's rising)
 is_falling = ta.falling(close, 3)
 log.info(is_falling)
 
-// Check rising for 1 bar (true, current > previous)
-is_rising1 = ta.rising(close, 1)
-log.info(is_rising1)
-
 // Expected output:
-// true
+// false
+// false
+// false
+// false
+// false
 // false
 // true
+// false

--- a/tests/testdata/ta/rma.pine
+++ b/tests/testdata/ta/rma.pine
@@ -1,16 +1,19 @@
 // Test ta.rma (Rolling Moving Average / Wilder's Smoothing)
-// RMA uses alpha = 1/length for smoothing
-// RMA = alpha * current + (1 - alpha) * prev_RMA
-// More smoothed than EMA, often used in RSI
+// Same recursion as ta.ema but with alpha = 1/length, so it smooths more
+// slowly. Over the last 4 bars close is 298, 299, 300, 301.
+//
+// Length 2 gives alpha = 0.5, so the arithmetic is exact:
+//   bar 2 seeds with mean(298,299)         -> 298.5
+//   bar 3: 0.5*300 + 0.5*298.5             -> 299.25
+//   bar 4: 0.5*301 + 0.5*299.25            -> 300.125
 
-// RMA with period 5
-rma5 = ta.rma(close, 5)
-log.info(rma5)
+// Bars: 4
 
-// RMA with period 14
-rma14 = ta.rma(close, 14)
-log.info(rma14)
+rma2 = ta.rma(close, 2)
+log.info(rma2)
 
 // Expected output:
-// 299.635008
-// 295.67359715525674
+// na
+// 298.5
+// 299.25
+// 300.125

--- a/tests/testdata/ta/roc.pine
+++ b/tests/testdata/ta/roc.pine
@@ -1,17 +1,17 @@
 // Test ta.roc (Rate of Change)
-// ROC = ((current - previous) / previous) * 100
-// Current close = 301 (bar 199)
-// 5 bars ago = 296 (bar 194)
-// roc(5) = ((301 - 296) / 296) * 100 = 1.689...
+// ROC = ((current - N bars ago) / N bars ago) * 100, so it needs N+1 values.
+// Over the last 6 bars close is 296..301.
 
-// Rate of Change over 5 bars
+// Bars: 6
+
+// ((301 - 296) / 296) * 100
 roc5 = ta.roc(close, 5)
 log.info(roc5)
 
-// Rate of Change over 10 bars
-roc10 = ta.roc(close, 10)
-log.info(roc10)
-
 // Expected output:
+// na
+// na
+// na
+// na
+// na
 // 1.6891891891891893
-// 3.436426116838488

--- a/tests/testdata/ta/rsi.pine
+++ b/tests/testdata/ta/rsi.pine
@@ -1,15 +1,25 @@
 // Test ta.rsi (Relative Strength Index)
-// RSI measures momentum, values between 0-100
-// Close is always increasing, so RSI should be 100
+// Wilder-smoothed gains over Wilder-smoothed losses. The first bar has no
+// previous value to difference against, and the averages then need `length`
+// changes, so with length 2 the first reading lands on the third bar.
+// Over the last 4 bars close is 298, 299, 300, 301.
 
-// RSI with period 14
-rsi14 = ta.rsi(close, 14)
-log.info(rsi14)
+// Bars: 4
 
-// RSI with period 7
-rsi7 = ta.rsi(close, 7)
-log.info(rsi7)
+// Every change is a gain, so losses stay at 0 and RSI saturates at 100.
+rsiUp = ta.rsi(close, 2)
+log.info(rsiUp)
+
+// Negating the source makes every change a loss, saturating at the other end.
+rsiDown = ta.rsi(-close, 2)
+log.info(rsiDown)
 
 // Expected output:
+// na
+// na
+// na
+// na
 // 100
+// 0
 // 100
+// 0

--- a/tests/testdata/ta/sma.pine
+++ b/tests/testdata/ta/sma.pine
@@ -1,20 +1,16 @@
 // Test ta.sma (Simple Moving Average)
-// Uses generated bars: bar[i] has close = 100 + i + 2 = 102 + i
-// For bar 199 (last bar): close = 301, bar 198: close = 300, etc.
+// Like Pine, na until the window has `length` bars. Over the last 5 bars close
+// is 297, 298, 299, 300, 301.
 
-// SMA of last 5 close values: (301+300+299+298+297)/5 = 299
-sma5 = ta.sma(close, 5)
-log.info(sma5)
+// Bars: 5
 
-// SMA of last 10 close values: (301+300+...+292)/10 = 296.5
-sma10 = ta.sma(close, 10)
-log.info(sma10)
-
-// SMA of last 20 close values: (301+300+...+282)/20 = 291.5
-sma20 = ta.sma(close, 20)
-log.info(sma20)
+// Windows [297,298,299], [298,299,300], [299,300,301]
+sma3 = ta.sma(close, 3)
+log.info(sma3)
 
 // Expected output:
+// na
+// na
+// 298
 // 299
-// 296.5
-// 291.5
+// 300

--- a/tests/testdata/ta/stdev.pine
+++ b/tests/testdata/ta/stdev.pine
@@ -1,15 +1,13 @@
-// Test ta.stdev (Standard Deviation)
-// Last 5 closes: 301, 300, 299, 298, 297
-// Mean = 299, StdDev = sqrt(((2^2 + 1^2 + 0 + 1^2 + 2^2) / 5)) = sqrt(2) ≈ 1.414
+// Test ta.stdev (Standard Deviation, population)
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301: mean 300, variance 2/3, stdev sqrt(2/3).
 
-// Standard deviation of last 5 closes
-stdev5 = ta.stdev(close, 5)
-log.info(stdev5)
+// Bars: 3
 
-// Standard deviation of last 10 closes
-stdev10 = ta.stdev(close, 10)
-log.info(stdev10)
+sd = ta.stdev(close, 3)
+log.info(sd)
 
 // Expected output:
-// 1.4142135623730951
-// 2.8722813232690143
+// na
+// na
+// 0.816496580927726

--- a/tests/testdata/ta/stoch.pine
+++ b/tests/testdata/ta/stoch.pine
@@ -1,25 +1,26 @@
 // Test ta.stoch (where source sits inside the recent high/low range, as 0..100)
-// Over the last 5 bars: highest high = 304, lowest low = 290, so range = 14.
-// On the current bar close = 301, high = 304, low = 294.
+// Needs `length` bars of high and low. Over the last 5 bars the highest high is
+// 304 and the lowest low is 290, so the range is 14 and close is 301.
+
+// Bars: 5
 
 // 100 * (301 - 290) / 14
 stochClose = ta.stoch(close, high, low, 5)
 log.info(stochClose)
 
-// The source sits at the top of the range: 100 * (304 - 290) / 14
-stochHigh = ta.stoch(high, high, low, 5)
-log.info(stochHigh)
-
-// 100 * (294 - 290) / 14
-stochLow = ta.stoch(low, high, low, 5)
-log.info(stochLow)
-
-// A single bar collapses the range to high - low = 10: 100 * (301 - 294) / 10
+// Length 1 fills immediately: each bar's own range is high - low = 10, and
+// close sits 7 above the low, so this is 70 on every bar.
 stochOneBar = ta.stoch(close, high, low, 1)
 log.info(stochOneBar)
 
 // Expected output:
+// na
+// 70
+// na
+// 70
+// na
+// 70
+// na
+// 70
 // 78.57142857142857
-// 100
-// 28.571428571428573
 // 70

--- a/tests/testdata/ta/swma.pine
+++ b/tests/testdata/ta/swma.pine
@@ -1,11 +1,15 @@
 // Test ta.swma (Symmetrically Weighted Moving Average)
-// SWMA uses fixed 4-bar window with weights [1, 2, 2, 1]
-// Last 4 closes: 301, 300, 299, 298
-// SWMA = (301*1 + 300*2 + 299*2 + 298*1) / 6 = 1799/6 = 299.833...
+// A fixed 4-bar window weighted 1, 2, 2, 1 from newest to oldest.
+// Over the last 4 bars close is 298, 299, 300, 301.
 
-// SWMA (no parameters - always 4 bars)
-swma_val = ta.swma(close)
-log.info(swma_val)
+// Bars: 4
+
+// (301 + 2*300 + 2*299 + 298) / 6 = 1797 / 6
+swmaClose = ta.swma(close)
+log.info(swmaClose)
 
 // Expected output:
+// na
+// na
+// na
 // 299.5

--- a/tests/testdata/ta/tr.pine
+++ b/tests/testdata/ta/tr.pine
@@ -1,17 +1,20 @@
 // Test ta.tr (True Range)
-// True Range = max(high-low, abs(high-close[1]), abs(low-close[1]))
-// At bar 199: high=306, low=296, close[1]=300
-// TR = max(306-296, abs(306-300), abs(296-300))
-// TR = max(10, 6, 4) = 10
+// max(high-low, abs(high-close[1]), abs(low-close[1])). Every fixture bar
+// spans 10 and steps up by 1, so the bar's own range always wins.
+//
+// On the very first bar there is no previous close: the default falls back to
+// high - low, while handle_na=true asks for na instead.
 
-// True Range with default handle_na
-tr_default = ta.tr()
-log.info(tr_default)
+// Bars: 2
 
-// True Range with handle_na=true
-tr_handle_na = ta.tr(true)
-log.info(tr_handle_na)
+trDefault = ta.tr()
+log.info(trDefault)
+
+trHandleNa = ta.tr(true)
+log.info(trHandleNa)
 
 // Expected output:
+// 10
+// na
 // 10
 // 10

--- a/tests/testdata/ta/variance.pine
+++ b/tests/testdata/ta/variance.pine
@@ -1,16 +1,13 @@
-// Test ta.variance (Variance)
-// Variance measures the spread of values from their mean
-// Last 5 closes: 301, 300, 299, 298, 297 (bar 195-199)
-// Mean = 299, Variance = 2
+// Test ta.variance (population variance)
+// Like Pine, na until the window has `length` bars. Over the last 3 bars close
+// is 299, 300, 301: mean 300, so (1 + 0 + 1) / 3.
 
-// Variance of last 5 closes
-var5 = ta.variance(close, 5)
-log.info(var5)
+// Bars: 3
 
-// Variance of last 10 closes
-var10 = ta.variance(close, 10)
-log.info(var10)
+v = ta.variance(close, 3)
+log.info(v)
 
 // Expected output:
-// 2
-// 8.25
+// na
+// na
+// 0.6666666666666666

--- a/tests/testdata/ta/vwma.pine
+++ b/tests/testdata/ta/vwma.pine
@@ -1,15 +1,16 @@
 // Test ta.vwma (Volume Weighted Moving Average)
-// VWMA = sum(price * volume) / sum(volume)
-// Gives more weight to bars with higher volume
+// sum(price * volume) / sum(volume) over the window. Over the last 5 bars
+// close is 297..301 and volume is 2950, 2960, 2970, 2980, 2990.
 
-// VWMA with period 5
+// Bars: 5
+
+// 4440250 / 14850
 vwma5 = ta.vwma(close, 5)
 log.info(vwma5)
 
-// VWMA with period 10
-vwma10 = ta.vwma(close, 10)
-log.info(vwma10)
-
 // Expected output:
+// na
+// na
+// na
+// na
 // 299.006734006734
-// 296.52801358234296


### PR DESCRIPTION
This PR introduces state on the builtins such that they can accumulate the state they need for their computation and we can get rid of the historical provider which anyway it was not useful to calculate arbitrary expressions on builtin calls.