### PR TITLE
tests: remove MPL license headers from testdata fixtures

### DIFF
--- a/tests/testdata/basics/na_propagation.pine
+++ b/tests/testdata/basics/na_propagation.pine
@@ -1,8 +1,5 @@
 //@version=5
 indicator("basics/na_propagation")
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // Pine v6 na propagation semantics
 

--- a/tests/testdata/loops/var_init_once_in_loop.pine
+++ b/tests/testdata/loops/var_init_once_in_loop.pine
@@ -1,8 +1,5 @@
 //@version=5
 indicator("loops/var_init_once_in_loop")
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // Pine `var` semantics inside a loop body: the initializer runs only the
 // FIRST time execution reaches the declaration (once ever) — NOT once per


### PR DESCRIPTION
Follow-up to review feedback on #49 ("Please do not put License headers").

Removes the per-file Mozilla Public License Exhibit A notice from the two testdata scripts that still carry it:

- `tests/testdata/basics/na_propagation.pine`
- `tests/testdata/loops/var_init_once_in_loop.pine`

The repo's top-level `LICENSE` already governs these files, MPL-2.0 does not require per-file headers, and they aren't wanted on testdata fixtures. Only comment lines are removed; `test_integration_scripts` still passes with the expected-output blocks unchanged.