### PR TITLE
`LibraryLoader` trait only imports plain source code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,13 +1485,10 @@ name = "pine-integration-tests"
 version = "0.1.0"
 dependencies = [
  "eyre",
- "pine-ast",
  "pine-core",
  "pine-data",
  "pine-interpreter",
  "pine-lang",
- "pine-lexer",
- "pine-parser",
  "walkdir",
 ]
 
@@ -1503,7 +1500,6 @@ dependencies = [
  "pine-ast",
  "pine-broker",
  "pine-core",
- "pine-lexer",
  "pine-parser",
  "thiserror",
 ]

--- a/benches/src/interpreter.rs
+++ b/benches/src/interpreter.rs
@@ -38,6 +38,7 @@ fn bench_compile_only(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(name), source, |b, source| {
             b.iter(|| {
                 let _ = ScriptBuilder::<DefaultPineOutput>::with_code(black_box(source))
+                    .with_data(pine_lang::core::Data::default())
                     .compile()
                     .unwrap();
             });

--- a/crates/pine-core/src/lib.rs
+++ b/crates/pine-core/src/lib.rs
@@ -1,9 +1,11 @@
 mod bar;
+mod library;
 mod syminfo;
 mod timeframe;
 mod version;
 
 pub use bar::{Bar, Data, Ohlcv};
+pub use library::{FileResolver, LibraryLoader};
 pub use syminfo::SymInfo;
 pub use timeframe::{Timeframe, TimeframeError, TimeframeUnit};
 pub use version::{PineVersion, VersionError};

--- a/crates/pine-core/src/library.rs
+++ b/crates/pine-core/src/library.rs
@@ -1,0 +1,41 @@
+//! Resolving `import`ed libraries to their source.
+
+use std::collections::HashMap;
+
+/// Loads the source of a library by its import path.
+pub trait LibraryLoader {
+    fn load_library(&self, path: &str) -> Result<String, String>;
+}
+
+/// A [`LibraryLoader`] backed by an in-memory set of named sources: register a
+/// library's text under a path and `import <path>` resolves against it.
+#[derive(Debug, Default, Clone)]
+pub struct FileResolver {
+    files: HashMap<String, String>,
+}
+
+impl FileResolver {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `source` under `path` in place.
+    pub fn add(&mut self, path: &str, source: &str) {
+        self.files.insert(path.to_string(), source.to_string());
+    }
+
+    /// Register `source` under `path`, returning self for chaining.
+    pub fn with_file(mut self, path: &str, source: &str) -> Self {
+        self.add(path, source);
+        self
+    }
+}
+
+impl LibraryLoader for FileResolver {
+    fn load_library(&self, path: &str) -> Result<String, String> {
+        self.files
+            .get(path)
+            .cloned()
+            .ok_or_else(|| format!("no library registered for '{path}'"))
+    }
+}

--- a/crates/pine-interpreter/Cargo.toml
+++ b/crates/pine-interpreter/Cargo.toml
@@ -11,9 +11,8 @@ homepage.workspace = true
 pine-ast = { workspace = true }
 pine-broker = { workspace = true }
 pine-core = { workspace = true }
+pine-parser = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-pine-lexer = { workspace = true }
-pine-parser = { workspace = true }
 eyre = { workspace = true }

--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -24,10 +24,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use thiserror::Error;
 
-pub trait LibraryLoader {
-    /// Return the source of the library at `path`
-    fn load_library(&self, path: &str) -> Result<String, String>;
-}
+pub use pine_core::LibraryLoader;
 
 /// Record `value` as what `name` held on a completed bar, so `name[n]` can reach
 /// it. Entries beyond [`MAX_LOOKBACK`] are dropped.

--- a/crates/pine-interpreter/src/lib.rs
+++ b/crates/pine-interpreter/src/lib.rs
@@ -24,10 +24,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use thiserror::Error;
 
-/// Trait for loading external libraries
 pub trait LibraryLoader {
-    /// Load a library from the given path and return its Program AST
-    fn load_library(&self, path: &str) -> Result<Program, String>;
+    /// Return the source of the library at `path`
+    fn load_library(&self, path: &str) -> Result<String, String>;
 }
 
 /// Record `value` as what `name` held on a completed bar, so `name[n]` can reach
@@ -1092,56 +1091,48 @@ impl<O: PineOutput> Interpreter<O> {
             }
 
             Stmt::Import { path, alias } => {
-                // Try to load the library - fail if no loader is available
-                if let Some(ref loader) = self.library_loader {
-                    match loader.load_library(path) {
-                        Ok(library_program) => {
-                            // Create a new interpreter for the library
-                            let mut library_interp = Interpreter::new();
-
-                            // Execute the library program (without a bar context for simplicity)
-                            library_interp.execute(&library_program)?;
-
-                            // Get the exports from the library
-                            let library_exports = library_interp.exports();
-
-                            // Import methods from the library
-                            for (method_name, method_defs) in &library_interp.methods {
-                                for method_def in method_defs {
-                                    self.methods
-                                        .entry(method_name.clone())
-                                        .or_default()
-                                        .push(method_def.clone());
-                                }
-                            }
-
-                            // Create a namespace object containing the exported items
-                            let namespace: Value<O> = Value::Object {
-                                type_name: alias.clone(),
-                                fields: Rc::new(RefCell::new(library_exports.clone())),
-                                call: None,
-                            };
-                            self.variables.insert(
-                                alias.clone(),
-                                Variable {
-                                    value: namespace,
-                                    is_const: false,
-                                    is_var_persistent: false,
-                                },
-                            );
-                        }
-                        Err(e) => {
-                            return Err(RuntimeError::LibraryError(format!(
-                                "Failed to load library '{}': {}",
-                                path, e
-                            )));
-                        }
+                let source = match &self.library_loader {
+                    Some(loader) => loader.load_library(path),
+                    None => {
+                        return Err(RuntimeError::LibraryError(
+                            "Cannot import library: no library loader configured".to_string(),
+                        ))
                     }
-                } else {
-                    return Err(RuntimeError::LibraryError(
-                        "Cannot import library: no library loader configured".to_string(),
-                    ));
                 }
+                .map_err(|e| {
+                    RuntimeError::LibraryError(format!("Failed to load library '{}': {}", path, e))
+                })?;
+
+                let library_program = pine_parser::Parser::parse_source(&source).map_err(|e| {
+                    RuntimeError::LibraryError(format!("Failed to parse library '{}': {}", path, e))
+                })?;
+
+                let mut library_interp = Interpreter::new();
+                library_interp.execute(&library_program)?;
+                let library_exports = library_interp.exports();
+
+                for (method_name, method_defs) in &library_interp.methods {
+                    for method_def in method_defs {
+                        self.methods
+                            .entry(method_name.clone())
+                            .or_default()
+                            .push(method_def.clone());
+                    }
+                }
+
+                let namespace: Value<O> = Value::Object {
+                    type_name: alias.clone(),
+                    fields: Rc::new(RefCell::new(library_exports.clone())),
+                    call: None,
+                };
+                self.variables.insert(
+                    alias.clone(),
+                    Variable {
+                        value: namespace,
+                        is_const: false,
+                        is_var_persistent: false,
+                    },
+                );
                 Ok(None)
             }
 

--- a/crates/pine-parser/src/lib.rs
+++ b/crates/pine-parser/src/lib.rs
@@ -25,6 +25,9 @@ pub enum ParserError {
 
     #[error("Expected identifier after '.' at line {0}")]
     ExpectedIdentifierAfterDot(usize),
+
+    #[error(transparent)]
+    Lexer(#[from] pine_lexer::LexerError),
 }
 
 impl From<ParserError> for String {
@@ -77,6 +80,12 @@ impl Parser {
             current: 0,
             next_call_id: 1,
         }
+    }
+
+    /// Lex and parse `source` into a program in one step.
+    pub fn parse_source(source: &str) -> Result<Program, ParserError> {
+        let tokens = pine_lexer::Lexer::new(source).tokenize()?;
+        Ok(Program::new(Self::new(tokens).parse()?))
     }
 
     fn next_call_id(&mut self) -> u32 {

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -12,7 +12,7 @@ mod backtest;
 mod run;
 
 pub use backtest::Backtest;
-pub use pine_core::DataProvider;
+pub use pine_core::{DataProvider, FileResolver, LibraryLoader};
 pub use run::{Run, RunResult};
 
 use pine_ast::Program;
@@ -20,7 +20,7 @@ use pine_core::{Bar, Data, PineVersion, Timeframe, VersionError};
 use pine_diagnostics::Diagnostic;
 use pine_interpreter::{
     AlertConditionOutput, BoxOutput, FillOutput, GlobalOutput, IndicatorOutput, InputOutput,
-    Interpreter, LabelOutput, LibraryLoader, LineOutput, LogOutput, PineOutput, PlotOutput,
+    Interpreter, LabelOutput, LineOutput, LogOutput, PineOutput, PlotOutput,
     RuntimeError, TableOutput, Value,
 };
 use pine_lexer::{Lexer, LexerError};

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -20,8 +20,8 @@ use pine_core::{Bar, Data, PineVersion, Timeframe, VersionError};
 use pine_diagnostics::Diagnostic;
 use pine_interpreter::{
     AlertConditionOutput, BoxOutput, FillOutput, GlobalOutput, IndicatorOutput, InputOutput,
-    Interpreter, LabelOutput, LineOutput, LogOutput, PineOutput, PlotOutput,
-    RuntimeError, TableOutput, Value,
+    Interpreter, LabelOutput, LineOutput, LogOutput, PineOutput, PlotOutput, RuntimeError,
+    TableOutput, Value,
 };
 use pine_lexer::{Lexer, LexerError};
 use pine_parser::{Parser, ParserError};

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,9 +15,6 @@ path = "corpus.rs"
 [dependencies]
 pine-lang.workspace = true
 pine-interpreter.workspace = true
-pine-lexer.workspace = true
-pine-parser.workspace = true
-pine-ast.workspace = true
 pine-core.workspace = true
 pine-data.workspace = true
 eyre.workspace = true

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use pine_ast::Program;
     use pine_core::{SymInfo, Timeframe, TimeframeUnit};
     use pine_data::StaticProvider;
     use pine_interpreter::{AlertConditionOutput, DefaultPineOutput, LibraryLoader, LogOutput};
     use pine_lang::ScriptBuilder;
-    use pine_lexer::Lexer;
-    use pine_parser::Parser;
     use std::fs;
     use std::path::{Path, PathBuf};
 
@@ -91,22 +88,10 @@ mod tests {
     }
 
     impl LibraryLoader for TestLibraryLoader {
-        fn load_library(&self, path: &str) -> Result<pine_ast::Program, String> {
+        fn load_library(&self, path: &str) -> Result<String, String> {
             let file_path = self.base_path.join(format!("{}.pine", path));
-
-            let source = fs::read_to_string(&file_path)
-                .map_err(|e| format!("Failed to load library {}: {}", path, e))?;
-
-            let mut lexer = Lexer::new(&source);
-            let tokens = lexer
-                .tokenize()
-                .map_err(|e| format!("Lexer error: {:?}", e))?;
-            let mut parser = Parser::new(tokens);
-            let statements = parser
-                .parse()
-                .map_err(|e| format!("Parser error: {:?}", e))?;
-
-            Ok(Program::new(statements))
+            fs::read_to_string(&file_path)
+                .map_err(|e| format!("Failed to load library {}: {}", path, e))
         }
     }
 


### PR DESCRIPTION
Before, the `LibraryLoader` trait was in charge of both loading the source code and generating a `Program` instance. Now, it only returns the source code.