### PR TITLE
Add more `sema` checks

### DIFF
--- a/crates/pine-sema/src/analyzer.rs
+++ b/crates/pine-sema/src/analyzer.rs
@@ -299,7 +299,8 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
     }
 
     fn warn(&mut self, rule: &'static str, pos: Option<(u32, u32)>, message: impl Into<String>) {
-        self.diagnostics.push(Diagnostic::warning(rule, pos, message));
+        self.diagnostics
+            .push(Diagnostic::warning(rule, pos, message));
     }
 
     /// Declaring a name that a built-in already owns hides the built-in. Pine

--- a/crates/pine-sema/src/analyzer.rs
+++ b/crates/pine-sema/src/analyzer.rs
@@ -7,9 +7,9 @@
 //! global-vs-local), which the default recurse-everything walk doesn't express.
 //! So we hand-write the recursion and interleave the scope bookkeeping.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use pine_ast::{Argument, Expr, Literal, Program, Stmt};
+use pine_ast::{Argument, Expr, FunctionParam, Literal, Program, Stmt};
 use pine_core::PineOutput;
 use pine_interpreter::{BuiltinSignature, Value};
 
@@ -30,10 +30,37 @@ pub struct Analyzer<'a, O: PineOutput> {
     /// How many script declarations (`indicator`/`strategy`/`library`) have been
     /// seen. A script may have at most one.
     declarations: u32,
+    /// User-declared free functions, `name -> (required, total)` parameter
+    /// counts, recorded as each declaration is walked so a later call can be
+    /// arity-checked. Methods are excluded (their receiver complicates arity).
+    functions: HashMap<String, (usize, usize)>,
+    /// Every user type/enum name, collected up front so an annotation may refer
+    /// to a type declared later in the file.
+    user_types: HashSet<String>,
+    /// The functions whose bodies enclose the point being analyzed; the last is
+    /// the one a call is currently being made from, so the call can be added to
+    /// the graph as an edge out of it.
+    fn_stack: Vec<String>,
+    /// The call graph, one entry per call: `(caller, callee, call-site)`. Built
+    /// during the walk and scanned afterwards — a callee that reaches back to its
+    /// caller closes a cycle, which is recursion (Pine forbids it).
+    call_edges: Vec<CallEdge>,
 }
+
+/// One call-graph edge: `(caller, callee, call-site position)`.
+type CallEdge = (String, String, Option<(u32, u32)>);
 
 /// The script-declaration functions — a script must have exactly one.
 const SCRIPT_DECLARATIONS: &[&str] = &["study", "indicator", "strategy", "library"];
+
+/// The built-in type names an annotation may name without a user declaration.
+/// Qualifiers (`series`/`simple`/`const`/`input`) are a separate field, and the
+/// generic collection forms (`array<…>`) are not captured as annotations, so a
+/// bare `array`/`matrix`/`map` is all that reaches here for those.
+const BUILTIN_TYPES: &[&str] = &[
+    "int", "float", "bool", "string", "color", "line", "linefill", "label", "box", "table",
+    "polyline", "array", "matrix", "map",
+];
 
 /// The called name as written, for diagnostics: `plot` or `ta.sma`.
 fn callee_name(callee: &Expr) -> String {
@@ -45,6 +72,30 @@ fn callee_name(callee: &Expr) -> String {
         },
         _ => String::new(),
     }
+}
+
+/// Whether `start` reaches `target` in the call graph. A direct self-call
+/// (`start == target`) counts, so this finds a node that participates in a cycle.
+fn reaches(start: &str, target: &str, adjacency: &HashMap<&str, Vec<&str>>) -> bool {
+    if start == target {
+        return true;
+    }
+    let mut stack = vec![start];
+    let mut seen = HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !seen.insert(node) {
+            continue;
+        }
+        if let Some(callees) = adjacency.get(node) {
+            for &callee in callees {
+                if callee == target {
+                    return true;
+                }
+                stack.push(callee);
+            }
+        }
+    }
+    false
 }
 
 /// How to name a literal's type in a diagnostic.
@@ -66,6 +117,10 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
             loop_depth: 0,
             builtins,
             declarations: 0,
+            functions: HashMap::new(),
+            user_types: HashSet::new(),
+            fn_stack: Vec::new(),
+            call_edges: Vec::new(),
         }
     }
 
@@ -197,14 +252,126 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
 
     /// Analyze a whole program, returning the errors found.
     pub fn analyze(mut self, program: &Program) -> Vec<Diagnostic> {
+        // Types are global and may be referenced by an annotation before their
+        // declaration, so collect their names before the ordered walk.
+        for stmt in &program.statements {
+            match stmt {
+                Stmt::TypeDecl { name, .. } | Stmt::EnumDecl { name, .. } => {
+                    self.user_types.insert(name.clone());
+                }
+                _ => {}
+            }
+        }
         for stmt in &program.statements {
             self.check_stmt(stmt);
         }
+        self.detect_recursion();
         self.diagnostics
+    }
+
+    /// Scan the call graph for cycles. An edge whose callee can reach its caller
+    /// again closes a cycle — the caller is (directly or indirectly) recursive,
+    /// which Pine forbids. Reported at the offending call site.
+    fn detect_recursion(&mut self) {
+        let cycles: Vec<CallEdge> = {
+            let mut adjacency: HashMap<&str, Vec<&str>> = HashMap::new();
+            for (caller, callee, _) in &self.call_edges {
+                adjacency.entry(caller).or_default().push(callee);
+            }
+            self.call_edges
+                .iter()
+                .filter(|(caller, callee, _)| reaches(callee, caller, &adjacency))
+                .cloned()
+                .collect()
+        };
+        for (caller, callee, pos) in cycles {
+            let message = if caller == callee {
+                format!("`{caller}` calls itself; Pine does not allow recursion")
+            } else {
+                format!("`{caller}` and `{callee}` call each other; Pine does not allow recursion")
+            };
+            self.emit("recursion", pos, message);
+        }
     }
 
     fn emit(&mut self, rule: &'static str, pos: Option<(u32, u32)>, message: impl Into<String>) {
         self.diagnostics.push(Diagnostic::error(rule, pos, message));
+    }
+
+    fn warn(&mut self, rule: &'static str, pos: Option<(u32, u32)>, message: impl Into<String>) {
+        self.diagnostics.push(Diagnostic::warning(rule, pos, message));
+    }
+
+    /// Declaring a name that a built-in already owns hides the built-in. Pine
+    /// allows it but warns, so this is a warning, not an error.
+    fn check_shadow(&mut self, name: &str) {
+        if self.is_builtin(name) {
+            self.warn(
+                "shadows-builtin",
+                None,
+                format!("declaration of `{name}` shadows a built-in"),
+            );
+        }
+    }
+
+    /// Reject a type annotation that names neither a built-in type nor a
+    /// user-declared type/enum. Array suffixes (`Foo[]`) share their element's
+    /// type name.
+    fn check_type_annotation(&mut self, annotation: Option<&String>) {
+        let Some(annotation) = annotation else {
+            return;
+        };
+        let base = annotation.trim_end_matches("[]");
+        if BUILTIN_TYPES.contains(&base) || self.user_types.contains(base) {
+            return;
+        }
+        self.emit("unknown-type", None, format!("unknown type `{base}`"));
+    }
+
+    /// Check a call's argument count against a user function's parameters, using
+    /// the same count-based bounds as the built-in checker.
+    fn check_call_arity(
+        &mut self,
+        name: &str,
+        supplied: usize,
+        required: usize,
+        total: usize,
+        pos: Option<(u32, u32)>,
+    ) {
+        if supplied < required {
+            self.emit(
+                "too-few-arguments",
+                pos,
+                format!("`{name}` requires at least {required} arguments, found {supplied}"),
+            );
+        } else if supplied > total {
+            self.emit(
+                "too-many-arguments",
+                pos,
+                format!("`{name}` takes at most {total} arguments, found {supplied}"),
+            );
+        }
+    }
+
+    /// Record a user function's arity, check its parameter annotations, and walk
+    /// its body with the name on the recursion stack. The name must already be
+    /// declared so a call to it inside the body reads as recursion.
+    fn analyze_function(&mut self, name: &str, params: &[FunctionParam], body: &[Stmt]) {
+        // A parameter with a default may be omitted, so it is not required.
+        let required = params.iter().filter(|p| p.default_value.is_none()).count();
+        self.functions
+            .insert(name.to_string(), (required, params.len()));
+        for param in params {
+            self.check_type_annotation(param.type_annotation.as_ref());
+        }
+        self.fn_stack.push(name.to_string());
+        self.function_body(
+            params
+                .iter()
+                .map(|p| (p.name.as_str(), p.default_value.as_ref())),
+            body,
+        );
+        self.fn_stack.pop();
     }
 
     /// Declare `name` in the current scope, reporting a duplicate if it already
@@ -253,7 +420,14 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
             if let Some(default) = default {
                 self.check_expr(default);
             }
-            self.scopes.declare(name, SymbolKind::Var);
+            self.check_shadow(name);
+            if self.scopes.declare(name, SymbolKind::Var).is_some() {
+                self.emit(
+                    "duplicate-parameter",
+                    None,
+                    format!("parameter `{name}` is declared more than once"),
+                );
+            }
         }
         for stmt in body {
             self.check_stmt(stmt);
@@ -265,21 +439,35 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
     fn check_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::VarDecl {
-                name, initializer, ..
+                name,
+                initializer,
+                type_annotation,
+                ..
             } => {
-                // Check the initializer *before* declaring the name, so a
-                // self-reference (`x = x`) resolves against the outer scope.
-                if let Some(init) = initializer {
-                    self.check_expr(init);
-                }
-                if self.scopes.declare(name, SymbolKind::Var).is_some() {
-                    self.emit(
-                        "duplicate-declaration",
-                        None,
-                        format!(
-                            "`{name}` is already declared in this scope (use `:=` to reassign)"
-                        ),
-                    );
+                self.check_type_annotation(type_annotation.as_ref());
+                self.check_shadow(name);
+                if let Some(Expr::Function { params, body }) = initializer {
+                    // A named function definition `f(x) => …`, which the parser
+                    // lowers to a lambda-valued variable. Declare it first so a
+                    // call to it inside its body reads as recursion, and record
+                    // it as a function so calls resolve and are arity-checked.
+                    self.declare(name, SymbolKind::Function);
+                    self.analyze_function(name, params, body);
+                } else {
+                    // Check the initializer *before* declaring the name, so a
+                    // self-reference (`x = x`) resolves against the outer scope.
+                    if let Some(init) = initializer {
+                        self.check_expr(init);
+                    }
+                    if self.scopes.declare(name, SymbolKind::Var).is_some() {
+                        self.emit(
+                            "duplicate-declaration",
+                            None,
+                            format!(
+                                "`{name}` is already declared in this scope (use `:=` to reassign)"
+                            ),
+                        );
+                    }
                 }
             }
             Stmt::Assignment { target, value } => {
@@ -289,6 +477,7 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
             Stmt::TupleAssignment { names, value } => {
                 self.check_expr(value);
                 for name in names {
+                    self.check_shadow(name);
                     if self.scopes.declare(name, SymbolKind::Var).is_some() {
                         self.emit(
                             "duplicate-declaration",
@@ -324,6 +513,7 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
                 self.check_expr(from);
                 self.check_expr(to);
                 self.scopes.push();
+                self.check_shadow(var_name);
                 self.scopes.declare(var_name, SymbolKind::Var);
                 self.loop_body(body);
                 self.scopes.pop();
@@ -337,8 +527,10 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
                 self.check_expr(collection);
                 self.scopes.push();
                 if let Some(idx) = index_var {
+                    self.check_shadow(idx);
                     self.scopes.declare(idx, SymbolKind::Var);
                 }
+                self.check_shadow(item_var);
                 self.scopes.declare(item_var, SymbolKind::Var);
                 self.loop_body(body);
                 self.scopes.pop();
@@ -355,17 +547,16 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
                 name, params, body, ..
             } => {
                 // Declare the name first so the body may reference it.
+                self.check_shadow(name);
                 self.declare(name, SymbolKind::Function);
-                self.function_body(
-                    params
-                        .iter()
-                        .map(|p| (p.name.as_str(), p.default_value.as_ref())),
-                    body,
-                );
+                self.analyze_function(name, params, body);
             }
             Stmt::MethodDecl { params, body, .. } => {
                 // Methods may share a name (overload by receiver type), so the
                 // name is not declared/duplicate-checked; just check the body.
+                for param in params {
+                    self.check_type_annotation(param.type_annotation.as_ref());
+                }
                 self.function_body(
                     params
                         .iter()
@@ -373,7 +564,12 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
                     body,
                 );
             }
-            Stmt::TypeDecl { name, .. } => self.declare(name, SymbolKind::Type),
+            Stmt::TypeDecl { name, fields, .. } => {
+                self.declare(name, SymbolKind::Type);
+                for field in fields {
+                    self.check_type_annotation(Some(&field.type_annotation));
+                }
+            }
             Stmt::EnumDecl { name, .. } => self.declare(name, SymbolKind::Enum),
             Stmt::Import { alias, .. } => self.declare(alias, SymbolKind::Import),
             // `export` re-exports an already-declared item; nothing to resolve.
@@ -452,12 +648,36 @@ impl<'a, O: PineOutput> Analyzer<'a, O> {
                             );
                         }
                     }
-                    if self.scopes.resolve(fname).is_none() && !self.is_builtin(fname) {
-                        self.emit(
-                            "unknown-function",
-                            pos,
-                            format!("unknown function `{fname}`"),
-                        );
+                    match self.scopes.resolve(fname) {
+                        Some(SymbolKind::Function) => {
+                            // Record the call as an edge out of the enclosing
+                            // function; cycles are found once the walk finishes.
+                            if let Some(caller) = self.fn_stack.last() {
+                                self.call_edges.push((caller.clone(), fname.clone(), pos));
+                            }
+                            if let Some(&(required, total)) = self.functions.get(fname) {
+                                self.check_call_arity(fname, args.len(), required, total, pos);
+                            }
+                        }
+                        // A value, type or enum is not callable.
+                        Some(kind @ (SymbolKind::Var | SymbolKind::Type | SymbolKind::Enum)) => {
+                            self.emit(
+                                "not-callable",
+                                pos,
+                                format!("`{fname}` is a {}, not a function", kind.noun()),
+                            );
+                        }
+                        // An import alias is called through its members, not directly.
+                        Some(SymbolKind::Import) => {}
+                        None => {
+                            if !self.is_builtin(fname) {
+                                self.emit(
+                                    "unknown-function",
+                                    pos,
+                                    format!("unknown function `{fname}`"),
+                                );
+                            }
+                        }
                     }
                 } else {
                     self.check_expr(callee);

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -254,10 +254,13 @@ impl<O: PineOutput> ScriptBuilder<O> {
             builtins.insert(name.clone(), value.clone());
         }
 
-        // Semantic pre-check: reject invalid programs before execution.
-        let diagnostics = pine_sema::analyze(&program, &builtins);
-        if !diagnostics.is_empty() {
-            return Err(Error::Sema(diagnostics));
+        // Semantic pre-check: reject if sema produces errors
+        let errors: Vec<_> = pine_sema::analyze(&program, &builtins)
+            .into_iter()
+            .filter(|diagnostic| diagnostic.severity == pine_diagnostics::Severity::Error)
+            .collect();
+        if !errors.is_empty() {
+            return Err(Error::Sema(errors));
         }
 
         // Create interpreter and load builtin namespace objects

--- a/tests/testdata/errors/duplicate_parameter.pine
+++ b/tests/testdata/errors/duplicate_parameter.pine
@@ -1,0 +1,8 @@
+//@version=5
+indicator("errors/duplicate_parameter")
+// A parameter name may appear only once.
+
+f(x, x) => x
+
+// Expected error:
+// error [duplicate-parameter]: parameter `x` is declared more than once

--- a/tests/testdata/errors/not_callable.pine
+++ b/tests/testdata/errors/not_callable.pine
@@ -1,0 +1,9 @@
+//@version=5
+indicator("errors/not_callable")
+// A value cannot be called like a function.
+
+x = 5
+y = x()
+
+// Expected error:
+// error [not-callable] 6:6: `x` is a variable, not a function

--- a/tests/testdata/errors/recursion.pine
+++ b/tests/testdata/errors/recursion.pine
@@ -1,0 +1,8 @@
+//@version=5
+indicator("errors/recursion")
+// Pine does not allow a function to call itself.
+
+f(x) => f(x - 1)
+
+// Expected error:
+// error [recursion] 5:10: `f` calls itself; Pine does not allow recursion

--- a/tests/testdata/errors/recursion_through_helper.pine
+++ b/tests/testdata/errors/recursion_through_helper.pine
@@ -1,0 +1,10 @@
+//@version=5
+indicator("errors/recursion_through_helper")
+// Recursion is found even when the self-call is nested inside another call; the
+// non-recursive helper is not flagged.
+
+double(x) => x * 2
+f(x) => double(f(x))
+
+// Expected error:
+// error [recursion] 7:17: `f` calls itself; Pine does not allow recursion

--- a/tests/testdata/errors/unknown_type.pine
+++ b/tests/testdata/errors/unknown_type.pine
@@ -1,0 +1,8 @@
+//@version=5
+indicator("errors/unknown_type")
+// A type annotation must name a built-in or a declared type.
+
+UnknownType x = na
+
+// Expected error:
+// error [unknown-type]: unknown type `UnknownType`

--- a/tests/testdata/errors/user_function_too_few_args.pine
+++ b/tests/testdata/errors/user_function_too_few_args.pine
@@ -1,0 +1,9 @@
+//@version=5
+indicator("errors/user_function_too_few_args")
+// A user function requires all of its non-defaulted parameters.
+
+f(a, b) => a + b
+x = f(1)
+
+// Expected error:
+// error [too-few-arguments] 6:6: `f` requires at least 2 arguments, found 1

--- a/tests/testdata/errors/user_function_too_many_args.pine
+++ b/tests/testdata/errors/user_function_too_many_args.pine
@@ -1,0 +1,9 @@
+//@version=5
+indicator("errors/user_function_too_many_args")
+// A user function rejects more arguments than it declares.
+
+f(a) => a
+x = f(1, 2)
+
+// Expected error:
+// error [too-many-arguments] 6:6: `f` takes at most 1 arguments, found 2


### PR DESCRIPTION
This PR adds the following Sema checks:
- Invalidates recursion calls.
- User-function arity
- Duplicate params
- Calling a non-callable
- Unknown type
- Shadowing